### PR TITLE
Add observed generation and samples.

### DIFF
--- a/config/crds/virt_v1alpha1_plan.yaml
+++ b/config/crds/virt_v1alpha1_plan.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Plan
     plural: plans
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -29,6 +31,11 @@ spec:
         spec:
           type: object
         status:
+          properties:
+            observedGeneration:
+              description: The most recent generation observed by the controller.
+              format: int64
+              type: integer
           type: object
   version: v1alpha1
 status:

--- a/config/samples/plan.yaml
+++ b/config/samples/plan.yaml
@@ -1,0 +1,8 @@
+---
+kind: Plan
+apiVersion: virt.migration.openshift.io/v1alpha1
+metadata:
+  name: test
+  namespace: openshift-migration
+spec:
+  placeholder: ""

--- a/pkg/apis/virt/v1alpha1/plan.go
+++ b/pkg/apis/virt/v1alpha1/plan.go
@@ -32,13 +32,18 @@ type PlanSpec struct {
 //
 // PlanStatus defines the observed state of Plan
 type PlanStatus struct {
+	// Conditions.
 	libcnd.Conditions
+	// The most recent generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type Plan struct {
 	v1.TypeMeta   `json:",inline"`
 	v1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -81,6 +81,8 @@ type Reconciler struct {
 // Reconcile a Plan CR.
 func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	var err error
+
+	// Reset the logger.
 	log.Reset()
 
 	// Fetch the CR.
@@ -107,8 +109,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	// Apply changes.
-	//plan.MarkReconciled()
-	err = r.Update(context.TODO(), plan)
+	plan.Status.ObservedGeneration = plan.Generation
+	err = r.Status().Update(context.TODO(), plan)
 	if err != nil {
 		log.Trace(err)
 		return reconcile.Result{Requeue: true}, nil

--- a/pkg/controller/plan/predicate.go
+++ b/pkg/controller/plan/predicate.go
@@ -3,7 +3,6 @@ package plan
 import (
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -23,21 +22,15 @@ func (r PlanPredicate) Create(e event.CreateEvent) bool {
 }
 
 func (r PlanPredicate) Update(e event.UpdateEvent) bool {
-	old, cast := e.ObjectOld.(*api.Plan)
+	object, cast := e.ObjectNew.(*api.Plan)
 	if !cast {
 		return false
 	}
-	new, cast := e.ObjectNew.(*api.Plan)
-	if !cast {
-		return false
-	}
-	changed := !reflect.DeepEqual(old.Spec, new.Spec) ||
-		!reflect.DeepEqual(
-			old.DeletionTimestamp,
-			new.DeletionTimestamp)
+	changed := object.Status.ObservedGeneration < object.Generation
 	if changed {
 		libref.Mapper.Update(e)
 	}
+
 	return changed
 }
 


### PR DESCRIPTION
Add support for _ObservedGeneration_.

Assuming that:
1. The controller will only run on Kubernetes 1.10+
2. We can avoid the need for the controller to ever update the `Spec`.

we can leverage the `Status` _subresource_ which simplifies things a bit.
For example, the status update does not cause the `Generation` to be incremented so the ObservedGeneration can simply be set equal  to the Generation.