### PR TITLE
Rename api group to 'virt.konveyor.io'

### DIFF
--- a/config/crds/virt_v1alpha1_migration.yaml
+++ b/config/crds/virt_v1alpha1_migration.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migrations.virt.migration.openshift.io
+  name: migrations.virt.konveyor.io
 spec:
-  group: virt.migration.openshift.io
+  group: virt.konveyor.io
   names:
     kind: Migration
     plural: migrations
@@ -31,6 +31,7 @@ spec:
         spec:
           properties:
             plan:
+              description: Reference to the associated Plan.
               type: object
           type: object
         status:

--- a/config/crds/virt_v1alpha1_plan.yaml
+++ b/config/crds/virt_v1alpha1_plan.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: plans.virt.migration.openshift.io
+  name: plans.virt.konveyor.io
 spec:
-  group: virt.migration.openshift.io
+  group: virt.konveyor.io
   names:
     kind: Plan
     plural: plans

--- a/config/samples/migration.yaml
+++ b/config/samples/migration.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Migration
-apiVersion: virt.migration.openshift.io/v1alpha1
+apiVersion: virt.konveyor.io/v1alpha1
 metadata:
   name: test
   namespace: openshift-migration

--- a/config/samples/plan.yaml
+++ b/config/samples/plan.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Plan
-apiVersion: virt.migration.openshift.io/v1alpha1
+apiVersion: virt.konveyor.io/v1alpha1
 metadata:
   name: test
   namespace: openshift-migration

--- a/pkg/apis/virt/v1alpha1/doc.go
+++ b/pkg/apis/virt/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/konveyor/virt-controller/pkg/apis
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=virt.migration.openshift.io
+// +groupName=virt.konveyor.io
 package v1alpha1

--- a/pkg/apis/virt/v1alpha1/register.go
+++ b/pkg/apis/virt/v1alpha1/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/konveyor/virt-controller/pkg/apis/migration
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=virt.migration.openshift.io
+// +groupName=virt.konveyor.io
 package v1alpha1
 
 import (
@@ -28,7 +28,7 @@ import (
 )
 
 var SchemeGroupVersion = schema.GroupVersion{
-	Group:   "virt.migration.openshift.io",
+	Group:   "virt.konveyor.io",
 	Version: "v1alpha1",
 }
 


### PR DESCRIPTION
`make manifests` didn't update the CRDs, so I had to do it manually. I think I got all the instances of it.