### PR TITLE
Add extensions; counts to provider REST resource.

### DIFF
--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -253,13 +253,9 @@ func (r *Reconciler) HasConsistency() bool {
 //
 // Start the reconciler.
 func (r *Reconciler) Start() error {
-	err := r.db.Open(true)
-	if err != nil {
-		return liberr.Wrap(err)
-	}
 	ctx := context.Background()
 	ctx, r.cancel = context.WithCancel(ctx)
-	err = r.connect(ctx)
+	err := r.connect(ctx)
 	if err != nil {
 		return liberr.Wrap(err)
 	}

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -27,6 +27,7 @@ import (
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/container"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/model"
+	ocpmodel "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
 	"github.com/konveyor/virt-controller/pkg/settings"
 	core "k8s.io/api/core/v1"
@@ -199,6 +200,16 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 func (r *Reconciler) updateContainer(provider *api.Provider) error {
 	db := r.getDB(provider)
 	secret, err := r.getSecret(provider)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	err = db.Open(true)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	pModel := &ocpmodel.Provider{}
+	pModel.With(provider)
+	err = db.Insert(pModel)
 	if err != nil {
 		return liberr.Wrap(err)
 	}

--- a/pkg/controller/provider/model/doc.go
+++ b/pkg/controller/provider/model/doc.go
@@ -3,6 +3,7 @@ package model
 import (
 	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/model/vsphere"
 )
 
@@ -11,7 +12,7 @@ import (
 var Log *logging.Logger
 
 func init() {
-	log := logging.WithName("vsphere")
+	log := logging.WithName("model")
 	Log = &log
 }
 
@@ -19,6 +20,11 @@ func init() {
 // All models.
 func Models(provider *api.Provider) (all []interface{}) {
 	switch provider.Type() {
+	case api.OpenShift:
+		ocp.Log = Log
+		all = append(
+			all,
+			ocp.All()...)
 	case api.VSphere:
 		vsphere.Log = Log
 		all = append(

--- a/pkg/controller/provider/model/ocp/doc.go
+++ b/pkg/controller/provider/model/ocp/doc.go
@@ -1,0 +1,20 @@
+package ocp
+
+import "github.com/konveyor/controller/pkg/logging"
+
+//
+// Shared logger.
+var Log *logging.Logger
+
+func init() {
+	log := logging.WithName("ocp")
+	Log = &log
+}
+
+//
+// Build all models.
+func All() []interface{} {
+	return []interface{}{
+		&Provider{},
+	}
+}

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -1,0 +1,101 @@
+package ocp
+
+import (
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/model/base"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	"path"
+)
+
+// Errors
+var NotFound = libmodel.NotFound
+
+//
+// Types
+type Model = libmodel.Model
+type Annotation = base.Annotation
+
+//
+// k8s Resource.
+type Resource interface {
+	meta.Object
+	runtime.Object
+}
+
+//
+// Base k8s model.
+type Base struct {
+	// PK
+	PK string `sql:"pk"`
+	// Object UID.
+	UID string `sql:""`
+	// Resource version.
+	Version string `sql:""`
+	// Namespace.
+	Namespace string `sql:"key"`
+	// Name.
+	Name string `sql:"key"`
+	// Json encoded (raw) object.
+	Object string `sql:""`
+	// Labels
+	labels libmodel.Labels
+}
+
+//
+// Populate fields with the specified k8s resource.
+func (m *Base) With(r Resource) {
+	m.UID = string(r.GetUID())
+	m.Version = r.GetResourceVersion()
+	m.Namespace = r.GetNamespace()
+	m.Name = r.GetName()
+	m.EncodeObject(r)
+}
+
+//
+// Encode (set) the object field.
+func (m *Base) EncodeObject(r interface{}) {
+	b, _ := json.Marshal(r)
+	m.Object = string(b)
+}
+
+//
+// Decode the object field.
+// `r` must be pointer to the appropriate k8s object.
+func (m *Base) DecodeObject(r interface{}) interface{} {
+	json.Unmarshal([]byte(m.Object), r)
+	return r
+}
+
+func (m *Base) Pk() string {
+	return m.PK
+}
+
+func (m *Base) String() string {
+	return path.Join(m.Namespace, m.Name)
+}
+
+func (m *Base) Equals(other Model) bool {
+	if b, cast := other.(*Base); cast {
+		return m.Namespace == b.Namespace &&
+			m.Name == b.Name
+	}
+
+	return false
+}
+
+func (m *Base) Labels() libmodel.Labels {
+	return m.labels
+}
+
+type Provider struct {
+	Base
+	Type string `sql:""`
+}
+
+func (m *Provider) With(p *api.Provider) {
+	m.Base.With(p)
+	m.Type = p.Type()
+}

--- a/pkg/controller/provider/model/vsphere/doc.go
+++ b/pkg/controller/provider/model/vsphere/doc.go
@@ -1,13 +1,16 @@
 package vsphere
 
-import "github.com/konveyor/controller/pkg/logging"
+import (
+	"github.com/konveyor/controller/pkg/logging"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
+)
 
 //
 // Shared logger.
 var Log *logging.Logger
 
 func init() {
-	log := logging.WithName("container")
+	log := logging.WithName("vsphere")
 	Log = &log
 }
 
@@ -15,6 +18,7 @@ func init() {
 // Build all models.
 func All() []interface{} {
 	return []interface{}{
+		&ocp.Provider{},
 		&Folder{},
 		&Datacenter{},
 		&Cluster{},

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -9,10 +9,6 @@ import (
 // Errors
 var NotFound = libmodel.NotFound
 
-const (
-	Assign = "assign"
-)
-
 //
 // Types
 type Model = libmodel.Model

--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -15,10 +15,12 @@ import (
 //
 // Root - all routes.
 const (
-	Root          = libweb.Root
-	NsParam       = libweb.NsParam
-	ProviderParam = "provider"
-	DetailParam   = "detail"
+	Root               = libweb.Root
+	ProviderCollection = "providers"
+	ProvidersRoot      = Root + "/" + ProviderCollection
+	NsParam            = libweb.NsParam
+	ProviderParam      = "provider"
+	DetailParam        = "detail"
 )
 
 //

--- a/pkg/controller/provider/web/doc.go
+++ b/pkg/controller/provider/web/doc.go
@@ -4,8 +4,9 @@ import (
 	"github.com/konveyor/controller/pkg/inventory/container"
 	libweb "github.com/konveyor/controller/pkg/inventory/web"
 	"github.com/konveyor/controller/pkg/logging"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/ocp"
-	vsphere "github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
 )
 
 //
@@ -23,6 +24,16 @@ func All(container *container.Container) (all []libweb.RequestHandler) {
 	vsphere.Log = Log
 	all = []libweb.RequestHandler{
 		&libweb.SchemaHandler{},
+		&NsHandler{
+			Handler: base.Handler{
+				Container: container,
+			},
+		},
+		&ProviderHandler{
+			Handler: base.Handler{
+				Container: container,
+			},
+		},
 	}
 	all = append(
 		all,

--- a/pkg/controller/provider/web/ns.go
+++ b/pkg/controller/provider/web/ns.go
@@ -1,0 +1,88 @@
+package web
+
+import (
+	"github.com/gin-gonic/gin"
+	libweb "github.com/konveyor/controller/pkg/inventory/web"
+	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
+	"net/http"
+)
+
+//
+// Ns handler.
+type NsHandler struct {
+	base.Handler
+}
+
+//
+// Add routes to the `gin` router.
+func (h *NsHandler) AddRoutes(e *gin.Engine) {
+	e.GET(libweb.NsCollection, h.List)
+	e.GET(libweb.NsCollection+"/", h.List)
+	e.GET(libweb.NsCollection+"/"+":"+base.NsParam, h.Get)
+}
+
+//
+// List resources in a REST collection.
+func (h NsHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	set := map[string]bool{}
+	list := h.Container.List()
+	for _, reconciler := range list {
+		if p, cast := reconciler.Owner().(*api.Provider); cast {
+			if p.Type() != api.VSphere {
+				continue
+			}
+			if reconciler, found := h.Container.Get(p); found {
+				h.Reconciler = reconciler
+			} else {
+				continue
+			}
+
+			set[p.Namespace] = true
+		}
+	}
+	content := []Namespace{}
+	for ns := range set {
+		content = append(
+			content, Namespace{
+				SelfLink: h.Link(ns),
+				Name:     ns,
+			})
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific REST resource.
+func (h NsHandler) Get(ctx *gin.Context) {
+	name := ctx.Param(base.NsParam)
+	content := Namespace{
+		SelfLink: h.Link(name),
+		Name:     name,
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link (URI).
+func (h NsHandler) Link(ns string) string {
+	return h.Handler.Link(
+		base.Root,
+		base.Params{
+			base.NsParam: ns,
+		})
+}
+
+//
+// REST Resource.
+type Namespace struct {
+	SelfLink string `json:"selfLink"`
+	Name     string `json:"name"`
+}

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -4,8 +4,8 @@ import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pathlib "path"
 	"reflect"
 	"strings"
@@ -91,8 +91,8 @@ func (c *Client) Path(object interface{}, id string) (path string, err error) {
 			ns = c.Provider.Namespace
 		}
 		h := ProviderHandler{}
-		path = h.Link(&api.Provider{
-			ObjectMeta: meta.ObjectMeta{
+		path = h.Link(&model.Provider{
+			Base: model.Base{
 				Namespace: ns,
 				Name:      name,
 			},

--- a/pkg/controller/provider/web/ocp/doc.go
+++ b/pkg/controller/provider/web/ocp/doc.go
@@ -11,7 +11,7 @@ import (
 //
 // Routes
 const (
-	Root = libweb.Root + "/" + api.OpenShift
+	Root = base.ProvidersRoot + "/" + api.OpenShift
 )
 
 type Handler = base.Handler

--- a/pkg/controller/provider/web/ocp/resource.go
+++ b/pkg/controller/provider/web/ocp/resource.go
@@ -1,8 +1,29 @@
 package ocp
 
+import (
+	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
+)
+
+//
+// REST Resource.
 type Resource struct {
-	UID       string `json:"uid"`
+	// k8s UID.
+	UID string `json:"uid"`
+	// k8s resource version.
+	Version string `json:"version"`
+	// k8s namespace.
 	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
-	SelfLink  string `json:"selfLink"`
+	// k8s name.
+	Name string `json:"name"`
+	// self link.
+	SelfLink string `json:"selfLink"`
+}
+
+//
+// Populate the fields with the specified object.
+func (r *Resource) With(m *model.Base) {
+	r.UID = m.UID
+	r.Version = m.Version
+	r.Namespace = m.Namespace
+	r.Name = m.Name
 }

--- a/pkg/controller/provider/web/provider.go
+++ b/pkg/controller/provider/web/provider.go
@@ -1,0 +1,93 @@
+package web
+
+import (
+	"github.com/gin-gonic/gin"
+	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/ocp"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
+
+	"net/http"
+)
+
+//
+// Routes.
+const (
+	ProvidersRoot = "/providers"
+)
+
+//
+// Provider handler.
+type ProviderHandler struct {
+	base.Handler
+}
+
+//
+// Add routes to the `gin` router.
+func (h *ProviderHandler) AddRoutes(e *gin.Engine) {
+	e.GET(base.ProvidersRoot, h.List)
+	e.GET(base.ProvidersRoot+"/", h.List)
+	e.GET(ProvidersRoot, h.List)
+	e.GET(ProvidersRoot+"/", h.List)
+}
+
+//
+// List resources in a REST collection.
+func (h ProviderHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	// OCP
+	ocpHandler := &ocp.ProviderHandler{
+		Handler: base.Handler{
+			Container: h.Container,
+		},
+	}
+	status = ocpHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	ocpList, err := ocpHandler.ListContent(ctx)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	// vSphere
+	vSphereHandler := &vsphere.ProviderHandler{
+		Handler: base.Handler{
+			Container: h.Container,
+		},
+	}
+	status = vSphereHandler.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	vSphereList, err := vSphereHandler.ListContent(ctx)
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r := Provider{
+		api.OpenShift: ocpList,
+		api.VSphere:   vSphereList,
+	}
+
+	content := r
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific REST resource.
+func (h ProviderHandler) Get(ctx *gin.Context) {
+}
+
+//
+// REST resource.
+type Provider map[string]interface{}

--- a/pkg/controller/provider/web/vsphere/client.go
+++ b/pkg/controller/provider/web/vsphere/client.go
@@ -1,13 +1,15 @@
-package web
+package vsphere
 
 import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	ocpmodel "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
 	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
-	"github.com/konveyor/virt-controller/pkg/controller/provider/web/ocp"
+	pathlib "path"
 	"reflect"
+	"strings"
 )
 
 //
@@ -81,11 +83,20 @@ func (c *Client) List(list interface{}) (int, error) {
 // Build the URL path.
 func (c *Client) Path(resource interface{}, id string) (path string, err error) {
 	switch resource.(type) {
-	case *ocp.Provider:
-		client := ocp.Client{
-			Provider: c.Provider,
+	case *Provider:
+		ns, name := pathlib.Split(id)
+		ns = strings.TrimSuffix(ns, "/")
+		if id == "" { // list
+			ns = c.Provider.Namespace
 		}
-		return client.Path(resource, id)
+		h := ProviderHandler{}
+		path = h.Link(
+			&ocpmodel.Provider{
+				Base: ocpmodel.Base{
+					Namespace: ns,
+					Name:      name,
+				},
+			})
 	case *Datacenter:
 		h := DatacenterHandler{}
 		path = h.Link(

--- a/pkg/controller/provider/web/vsphere/cluster.go
+++ b/pkg/controller/provider/web/vsphere/cluster.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 const (
 	ClusterParam      = "cluster"
 	ClusterCollection = "clusters"
-	ClustersRoot      = Root + "/" + ClusterCollection
+	ClustersRoot      = ProviderRoot + "/" + ClusterCollection
 	ClusterRoot       = ClustersRoot + "/:" + ClusterParam
 )
 

--- a/pkg/controller/provider/web/vsphere/datacenter.go
+++ b/pkg/controller/provider/web/vsphere/datacenter.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 const (
 	DatacenterParam      = "datacenter"
 	DatacenterCollection = "datacenters"
-	DatacentersRoot      = Root + "/" + DatacenterCollection
+	DatacentersRoot      = ProviderRoot + "/" + DatacenterCollection
 	DatacenterRoot       = DatacentersRoot + "/:" + DatacenterParam
 )
 

--- a/pkg/controller/provider/web/vsphere/datastore.go
+++ b/pkg/controller/provider/web/vsphere/datastore.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 const (
 	DatastoreParam      = "datastore"
 	DatastoreCollection = "datastores"
-	DatastoresRoot      = Root + "/" + DatastoreCollection
+	DatastoresRoot      = ProviderRoot + "/" + DatastoreCollection
 	DatastoreRoot       = DatastoresRoot + "/:" + DatastoreParam
 )
 

--- a/pkg/controller/provider/web/vsphere/doc.go
+++ b/pkg/controller/provider/web/vsphere/doc.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"github.com/konveyor/controller/pkg/inventory/container"
@@ -6,14 +6,15 @@ import (
 	"github.com/konveyor/controller/pkg/logging"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
-	"github.com/konveyor/virt-controller/pkg/controller/provider/web/ocp"
 )
 
 //
 // Routes
 const (
-	Root = ocp.ProviderRoot + "/" + api.VSphere
+	Root = base.ProvidersRoot + "/" + api.VSphere
 )
+
+type Handler = base.Handler
 
 //
 // Shared logger.
@@ -28,6 +29,11 @@ func init() {
 // Build all handlers.
 func Handlers(container *container.Container) []libweb.RequestHandler {
 	return []libweb.RequestHandler{
+		&ProviderHandler{
+			Handler: base.Handler{
+				Container: container,
+			},
+		},
 		&TreeHandler{
 			Handler: base.Handler{
 				Container: container,

--- a/pkg/controller/provider/web/vsphere/folder.go
+++ b/pkg/controller/provider/web/vsphere/folder.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 const (
 	FolderParam      = "folder"
 	FolderCollection = "folders"
-	FoldersRoot      = Root + "/" + FolderCollection
+	FoldersRoot      = ProviderRoot + "/" + FolderCollection
 	FolderRoot       = FoldersRoot + "/:" + FolderParam
 )
 

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 const (
 	HostParam      = "host"
 	HostCollection = "hosts"
-	HostsRoot      = Root + "/" + HostCollection
+	HostsRoot      = ProviderRoot + "/" + HostCollection
 	HostRoot       = HostsRoot + "/:" + HostParam
 )
 

--- a/pkg/controller/provider/web/vsphere/network.go
+++ b/pkg/controller/provider/web/vsphere/network.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 const (
 	NetworkParam      = "network"
 	NetworkCollection = "networks"
-	NetworksRoot      = Root + "/" + NetworkCollection
+	NetworksRoot      = ProviderRoot + "/" + NetworkCollection
 	NetworkRoot       = NetworksRoot + "/:" + NetworkParam
 )
 

--- a/pkg/controller/provider/web/vsphere/resource.go
+++ b/pkg/controller/provider/web/vsphere/resource.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/vsphere"

--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"github.com/gin-gonic/gin"
@@ -14,7 +14,7 @@ import (
 //
 // Routes.
 const (
-	TreeRoot     = Root + "/tree"
+	TreeRoot     = ProviderRoot + "/tree"
 	TreeHostRoot = TreeRoot + "/host"
 	TreeVmRoot   = TreeRoot + "/vm"
 )

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -1,4 +1,4 @@
-package web
+package vsphere
 
 import (
 	"errors"
@@ -15,7 +15,7 @@ import (
 const (
 	VMParam      = "vm"
 	VMCollection = "vms"
-	VMsRoot      = Root + "/" + VMCollection
+	VMsRoot      = ProviderRoot + "/" + VMCollection
 	VMRoot       = VMsRoot + "/:" + VMParam
 )
 

--- a/vendor/github.com/konveyor/controller/pkg/inventory/model/client.go
+++ b/vendor/github.com/konveyor/controller/pkg/inventory/model/client.go
@@ -31,8 +31,10 @@ type DB interface {
 	Get(Model) error
 	// Get for update of the specified model.
 	GetForUpdate(Model) (*Tx, error)
-	// List models based on `selector` model.
+	// List models based on the type of slice.
 	List(interface{}, ListOptions) error
+	// Count based on the specified model.
+	Count(Model, Predicate) (int64, error)
 	// Begin a transaction.
 	Begin() (*Tx, error)
 	// Insert a model.
@@ -149,6 +151,12 @@ func (r *Client) GetForUpdate(model Model) (*Tx, error) {
 // The `list` must be: *[]Model.
 func (r *Client) List(list interface{}, options ListOptions) error {
 	return Table{r.db}.List(list, options)
+}
+
+//
+// Count models.
+func (r *Client) Count(model Model, predicate Predicate) (int64, error) {
+	return Table{r.db}.Count(model, predicate)
 }
 
 //

--- a/vendor/github.com/konveyor/controller/pkg/inventory/model/model_test.go
+++ b/vendor/github.com/konveyor/controller/pkg/inventory/model/model_test.go
@@ -297,6 +297,14 @@ func TestList(t *testing.T) {
 	g.Expect(len(list)).To(gomega.Equal(2))
 	g.Expect(list[0].ID).To(gomega.Equal(4))
 	g.Expect(list[1].ID).To(gomega.Equal(8))
+	// Test count all.
+	count, err := DB.Count(&TestObject{}, nil)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(count).To(gomega.Equal(int64(10)))
+	// Test count with predicate.
+	count, err = DB.Count(&TestObject{}, Gt("ID", 0))
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(count).To(gomega.Equal(int64(9)))
 }
 
 func TestWatch(t *testing.T) {


### PR DESCRIPTION
Add type specific _extension_ filed to the `Provider` REST resource.  For both OCP and vSphere it needs to contain type specific counts needed by the UI.  Also added `?type=` parameter to provider collection for filtering.

The `Provider` resource is a little different in that technically it is part of the OCP (package) but really spans all provider types.  For consistency, I added a `Provider` model and update method signatures to use it.

Requires https://github.com/konveyor/controller/pull/18 (already vendor'd in)