### PR TITLE
Next iteration of valiations.

### DIFF
--- a/config/crds/virt_v1alpha1_networkmap.yaml
+++ b/config/crds/virt_v1alpha1_networkmap.yaml
@@ -68,6 +68,16 @@ spec:
               type: array
             provider:
               description: Provider
+              properties:
+                destination:
+                  description: Destination.
+                  type: object
+                source:
+                  description: Source.
+                  type: object
+              required:
+              - source
+              - destination
               type: object
           required:
           - provider

--- a/config/crds/virt_v1alpha1_plan.yaml
+++ b/config/crds/virt_v1alpha1_plan.yaml
@@ -30,6 +30,9 @@ spec:
           type: object
         spec:
           properties:
+            description:
+              description: Description
+              type: string
             map:
               description: Resource map.
               properties:

--- a/config/crds/virt_v1alpha1_storagemap.yaml
+++ b/config/crds/virt_v1alpha1_storagemap.yaml
@@ -60,6 +60,16 @@ spec:
               type: array
             provider:
               description: Provider
+              properties:
+                destination:
+                  description: Destination.
+                  type: object
+                source:
+                  description: Source.
+                  type: object
+              required:
+              - source
+              - destination
               type: object
           required:
           - provider

--- a/pkg/apis/virt/v1alpha1/map.go
+++ b/pkg/apis/virt/v1alpha1/map.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
-	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -71,7 +70,7 @@ type StoragePair struct {
 // Network map spec.
 type NetworkMapSpec struct {
 	// Provider
-	Provider core.ObjectReference `json:"provider" ref:"Provider"`
+	Provider ProviderPair `json:"provider" ref:"Provider"`
 	// Map.
 	Map []NetworkPair `json:"map"`
 }
@@ -80,7 +79,7 @@ type NetworkMapSpec struct {
 // Storage map spec.
 type StorageMapSpec struct {
 	// Provider
-	Provider core.ObjectReference `json:"provider" ref:"Provider"`
+	Provider ProviderPair `json:"provider" ref:"Provider"`
 	// Map.
 	Map []StoragePair `json:"map"`
 }

--- a/pkg/apis/virt/v1alpha1/plan.go
+++ b/pkg/apis/virt/v1alpha1/plan.go
@@ -23,15 +23,6 @@ import (
 )
 
 //
-// Plan provider pair.
-type ProviderPair struct {
-	// Source.
-	Source core.ObjectReference `json:"source" ref:"Provider"`
-	// Destination.
-	Destination core.ObjectReference `json:"destination" ref:"Provider"`
-}
-
-//
 // Plan hook.
 type PlanHook struct {
 	// Pre-migration hook.
@@ -65,6 +56,8 @@ type PlanMap struct {
 //
 // PlanSpec defines the desired state of Plan.
 type PlanSpec struct {
+	// Description
+	Description string `json:"description,omitempty"`
 	// Providers.
 	Provider ProviderPair `json:"provider"`
 	// Resource map.

--- a/pkg/apis/virt/v1alpha1/provider.go
+++ b/pkg/apis/virt/v1alpha1/provider.go
@@ -40,6 +40,15 @@ const (
 )
 
 //
+// Provider pair.
+type ProviderPair struct {
+	// Source.
+	Source core.ObjectReference `json:"source" ref:"Provider"`
+	// Destination.
+	Destination core.ObjectReference `json:"destination" ref:"Provider"`
+}
+
+//
 // Defines the desired state of Provider.
 type ProviderSpec struct {
 	// Provider type.

--- a/pkg/controller/host/controller.go
+++ b/pkg/controller/host/controller.go
@@ -18,6 +18,7 @@ package host
 
 import (
 	"context"
+	cnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
@@ -132,7 +133,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	// Ready condition.
 	if !host.Status.HasBlockerCondition() {
-		host.Status.SetReady(true, ReadyMessage)
+		host.Status.SetCondition(cnd.Condition{
+			Type:     cnd.Ready,
+			Status:   True,
+			Category: Required,
+			Message:  "The host is ready.",
+		})
 	}
 
 	// End staging conditions.

--- a/pkg/controller/map/network/controller.go
+++ b/pkg/controller/map/network/controller.go
@@ -18,11 +18,13 @@ package network
 
 import (
 	"context"
+	"errors"
+	cnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
 	"github.com/konveyor/virt-controller/pkg/settings"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -113,7 +115,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	mp := &api.NetworkMap{}
 	err = r.Get(context.TODO(), request.NamespacedName, mp)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serr.IsNotFound(err) {
 			return noReQ, nil
 		}
 		log.Trace(err)
@@ -126,13 +128,21 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(mp)
 	if err != nil {
+		if errors.Is(err, ProviderInvNotReady) {
+			return fastReQ, nil
+		}
 		log.Trace(err)
 		return fastReQ, nil
 	}
 
 	// Ready condition.
 	if !mp.Status.HasBlockerCondition() {
-		mp.Status.SetReady(true, ReadyMessage)
+		mp.Status.SetCondition(cnd.Condition{
+			Type:     cnd.Ready,
+			Status:   True,
+			Category: Required,
+			Message:  "The network map is ready.",
+		})
 	}
 
 	// End staging conditions.

--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -1,94 +1,57 @@
 package network
 
 import (
-	"context"
 	cnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
-	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-//
-// Types
-const (
-	ProviderNotValid = "ProviderNotValid"
+	"github.com/konveyor/virt-controller/pkg/controller/validation"
 )
 
 //
 // Categories
 const (
+	Required = cnd.Required
 	Advisory = cnd.Advisory
 	Critical = cnd.Critical
 	Error    = cnd.Error
 	Warn     = cnd.Warn
 )
 
+//
 // Reasons
 const (
 	NotSet   = "NotSet"
 	NotFound = "NotFound"
 )
 
+//
 // Statuses
 const (
 	True  = cnd.True
 	False = cnd.False
 )
 
-// Messages
-const (
-	ReadyMessage            = "The map is ready."
-	ProviderNotValidMessage = "`provider` not valid."
+//
+// Errors
+var (
+	ProviderInvNotReady = validation.ProviderInvNotReady
 )
 
 //
 // Validate the mp resource.
 func (r *Reconciler) validate(mp *api.NetworkMap) error {
-	err := r.validateProvider(mp)
+	provider := validation.ProviderPair{Client: r}
+	conditions, err := provider.Validate(mp.Spec.Provider)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-
-	return nil
-}
-
-//
-// Validate provider field.
-func (r *Reconciler) validateProvider(mp *api.NetworkMap) error {
-	ref := mp.Spec.Provider
-	if !libref.RefSet(&ref) {
-		mp.Status.SetCondition(
-			cnd.Condition{
-				Type:     ProviderNotValid,
-				Status:   True,
-				Reason:   NotSet,
-				Category: Critical,
-				Message:  ProviderNotValidMessage,
-			})
-	} else {
-		provider := &api.Provider{}
-		key := client.ObjectKey{
-			Namespace: ref.Namespace,
-			Name:      ref.Name,
-		}
-		err := r.Get(context.TODO(), key, provider)
-		if errors.IsNotFound(err) {
-			err = nil
-			mp.Status.SetCondition(
-				cnd.Condition{
-					Type:     ProviderNotValid,
-					Status:   True,
-					Reason:   NotFound,
-					Category: Critical,
-					Message:  ProviderNotValidMessage,
-				})
-		}
-		if err != nil {
-			return liberr.Wrap(err)
-		}
+	mp.Status.SetCondition(conditions.List...)
+	network := validation.NetworkPair{Client: r, Provider: provider.Referenced}
+	conditions, err = network.Validate(mp.Spec.Map)
+	if err != nil {
+		return liberr.Wrap(err)
 	}
+	mp.Status.SetCondition(conditions.List...)
 
 	return nil
 }

--- a/pkg/controller/map/storage/validation.go
+++ b/pkg/controller/map/storage/validation.go
@@ -1,94 +1,57 @@
 package storage
 
 import (
-	"context"
 	cnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
-	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-//
-// Types
-const (
-	ProviderNotValid = "ProviderNotValid"
+	"github.com/konveyor/virt-controller/pkg/controller/validation"
 )
 
 //
 // Categories
 const (
+	Required = cnd.Required
 	Advisory = cnd.Advisory
 	Critical = cnd.Critical
 	Error    = cnd.Error
 	Warn     = cnd.Warn
 )
 
+//
 // Reasons
 const (
 	NotSet   = "NotSet"
 	NotFound = "NotFound"
 )
 
+//
 // Statuses
 const (
 	True  = cnd.True
 	False = cnd.False
 )
 
-// Messages
-const (
-	ReadyMessage            = "The map is ready."
-	ProviderNotValidMessage = "`provider` not valid."
+//
+// Errors
+var (
+	ProviderInvNotReady = validation.ProviderInvNotReady
 )
 
 //
 // Validate the mp resource.
 func (r *Reconciler) validate(mp *api.StorageMap) error {
-	err := r.validateProvider(mp)
+	provider := validation.ProviderPair{Client: r}
+	conditions, err := provider.Validate(mp.Spec.Provider)
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-
-	return nil
-}
-
-//
-// Validate provider field.
-func (r *Reconciler) validateProvider(mp *api.StorageMap) error {
-	ref := mp.Spec.Provider
-	if !libref.RefSet(&ref) {
-		mp.Status.SetCondition(
-			cnd.Condition{
-				Type:     ProviderNotValid,
-				Status:   True,
-				Reason:   NotSet,
-				Category: Critical,
-				Message:  ProviderNotValidMessage,
-			})
-	} else {
-		provider := &api.Provider{}
-		key := client.ObjectKey{
-			Namespace: ref.Namespace,
-			Name:      ref.Name,
-		}
-		err := r.Get(context.TODO(), key, provider)
-		if errors.IsNotFound(err) {
-			err = nil
-			mp.Status.SetCondition(
-				cnd.Condition{
-					Type:     ProviderNotValid,
-					Status:   True,
-					Reason:   NotFound,
-					Category: Critical,
-					Message:  ProviderNotValidMessage,
-				})
-		}
-		if err != nil {
-			return liberr.Wrap(err)
-		}
+	mp.Status.SetCondition(conditions.List...)
+	storage := validation.StoragePair{Client: r, Provider: provider.Referenced}
+	conditions, err = storage.Validate(mp.Spec.Map)
+	if err != nil {
+		return liberr.Wrap(err)
 	}
+	mp.Status.SetCondition(conditions.List...)
 
 	return nil
 }

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -18,6 +18,7 @@ package migration
 
 import (
 	"context"
+	cnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
@@ -135,7 +136,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	// Ready condition.
 	if !migration.Status.HasBlockerCondition() {
-		migration.Status.SetReady(true, ReadyMessage)
+		migration.Status.SetCondition(cnd.Condition{
+			Type:     cnd.Ready,
+			Status:   True,
+			Category: Required,
+			Message:  "The migration is ready.",
+		})
 	}
 
 	// Run migration.

--- a/pkg/controller/migration/migrate.go
+++ b/pkg/controller/migration/migrate.go
@@ -178,7 +178,7 @@ func (r *Task) begin() {
 			Type:     Running,
 			Status:   True,
 			Category: Advisory,
-			Message:  RunningMessage,
+			Message:  "The migration is RUNNING.",
 			Durable:  true,
 		})
 	list := []api.VMStatus{}

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -19,6 +19,7 @@ package plan
 import (
 	"context"
 	"errors"
+	cnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
@@ -146,7 +147,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	// Ready condition.
 	if !plan.Status.HasBlockerCondition() {
-		plan.Status.SetReady(true, ReadyMessage)
+		plan.Status.SetCondition(cnd.Condition{
+			Type:     cnd.Ready,
+			Status:   True,
+			Category: Required,
+			Message:  "The migration plan is ready.",
+		})
 	}
 
 	// End staging conditions.

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	cnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libcontainer "github.com/konveyor/controller/pkg/inventory/container"
 	libmodel "github.com/konveyor/controller/pkg/inventory/model"
@@ -196,7 +197,12 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	// Ready condition.
 	if !provider.Status.HasBlockerCondition() {
-		provider.Status.SetReady(true, ReadyMessage)
+		provider.Status.SetCondition(cnd.Condition{
+			Type:     cnd.Ready,
+			Status:   True,
+			Category: Required,
+			Message:  "The provider is ready.",
+		})
 	}
 
 	// End staging conditions.

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -114,6 +114,28 @@ func (c *Client) Path(object interface{}, id string) (path string, err error) {
 				Name:      name,
 			},
 		})
+	case *StorageClass:
+		h := StorageClassHandler{}
+		path = h.Link(
+			&c.Provider,
+			&model.StorageClass{
+				Base: model.Base{
+					Name: name,
+				},
+			})
+	case *NetworkAttachmentDefinition:
+		if id == "" { // list
+			ns = c.Provider.Namespace
+		}
+		h := NetworkAttachmentDefinitionHandler{}
+		path = h.Link(
+			&c.Provider,
+			&model.NetworkAttachmentDefinition{
+				Base: model.Base{
+					Namespace: ns,
+					Name:      name,
+				},
+			})
 	default:
 		err = base.ResourceNotSupported
 	}

--- a/pkg/controller/validation/network.go
+++ b/pkg/controller/validation/network.go
@@ -1,0 +1,189 @@
+package validation
+
+import (
+	"fmt"
+	cnd "github.com/konveyor/controller/pkg/condition"
+	liberr "github.com/konveyor/controller/pkg/error"
+	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/ocp"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
+	"net/http"
+	"path"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//
+// Types
+const (
+	SourceNetworkNotValid      = "SourceNetworkNotValid"
+	DestinationNetworkNotValid = "DestinationNetworkNotValid"
+	NetworkTypeNotValid        = "NetworkTypeNotValid"
+)
+
+const (
+	Pod    = "pod"
+	Multus = "multus"
+)
+
+//
+// Network pair validation.
+type NetworkPair struct {
+	client.Client
+	Provider struct {
+		Source      *api.Provider
+		Destination *api.Provider
+	}
+}
+
+//
+// Validate pairs.
+func (r *NetworkPair) Validate(list []api.NetworkPair) (result cnd.Conditions, err error) {
+	conditions, err := r.validateSource(list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	result.SetCondition(conditions.List...)
+	conditions, err = r.validateDestination(list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	result.SetCondition(conditions.List...)
+
+	return
+}
+
+//
+// Validate source networks.
+func (r *NetworkPair) validateSource(list []api.NetworkPair) (result cnd.Conditions, err error) {
+	provider := r.Provider.Source
+	if provider == nil {
+		return
+	}
+	pClient, err := web.NewClient(*provider)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	notValid := []string{}
+	var resource interface{}
+	switch provider.Type() {
+	case api.OpenShift:
+		return
+	case api.VSphere:
+		resource = &vsphere.Network{}
+	default:
+		err = web.ProviderNotSupported
+		return
+	}
+	for _, entry := range list {
+		status, pErr := pClient.Get(resource, entry.Source.ID)
+		if pErr != nil {
+			err = liberr.Wrap(pErr)
+			return
+		}
+		switch status {
+		case http.StatusOK:
+		case http.StatusPartialContent:
+			err = liberr.Wrap(ProviderInvNotReady)
+			return
+		case http.StatusNotFound:
+			notValid = append(notValid, entry.Source.ID)
+		default:
+			err = liberr.New(http.StatusText(status))
+			return
+		}
+	}
+	if len(notValid) > 0 {
+		result.SetCondition(cnd.Condition{
+			Type:     SourceNetworkNotValid,
+			Status:   True,
+			Reason:   NotFound,
+			Category: Critical,
+			Message:  "Source network not valid.",
+		})
+	}
+
+	return
+}
+
+//
+// Validate destination networks.
+func (r *NetworkPair) validateDestination(list []api.NetworkPair) (result cnd.Conditions, err error) {
+	provider := r.Provider.Destination
+	if provider == nil {
+		return
+	}
+	pClient, err := web.NewClient(*provider)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	notFound := []string{}
+	notValid := []string{}
+	var resource interface{}
+	switch provider.Type() {
+	case api.OpenShift:
+		resource = &ocp.NetworkAttachmentDefinition{}
+	case api.VSphere:
+		return
+	default:
+		err = web.ProviderNotSupported
+		return
+	}
+next:
+	for _, entry := range list {
+		switch entry.Destination.Type {
+		case Pod:
+			continue next
+		case Multus:
+			id := path.Join(
+				entry.Destination.Namespace,
+				entry.Destination.Name)
+			status, pErr := pClient.Get(resource, id)
+			if pErr != nil {
+				err = liberr.Wrap(pErr)
+				return
+			}
+			switch status {
+			case http.StatusOK:
+			case http.StatusPartialContent:
+				err = liberr.Wrap(ProviderInvNotReady)
+				return
+			case http.StatusNotFound:
+				notFound = append(notFound, entry.Source.ID)
+			default:
+				err = liberr.New(http.StatusText(status))
+				return
+			}
+		default:
+			notValid = append(notValid, entry.Source.ID)
+		}
+	}
+	if len(notFound) > 0 {
+		result.SetCondition(cnd.Condition{
+			Type:     DestinationNetworkNotValid,
+			Status:   True,
+			Reason:   NotFound,
+			Category: Critical,
+			Message:  "Destination network not found.",
+		})
+	}
+	if len(notValid) > 0 {
+		valid := []string{
+			Pod,
+			Multus,
+		}
+		result.SetCondition(cnd.Condition{
+			Type:     NetworkTypeNotValid,
+			Status:   True,
+			Reason:   NotFound,
+			Category: Critical,
+			Message:  fmt.Sprintf("Network `type` must be: %s.", valid),
+		})
+	}
+
+	return
+}

--- a/pkg/controller/validation/provider.go
+++ b/pkg/controller/validation/provider.go
@@ -1,0 +1,240 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	cnd "github.com/konveyor/controller/pkg/condition"
+	liberr "github.com/konveyor/controller/pkg/error"
+	libref "github.com/konveyor/controller/pkg/ref"
+	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
+	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//
+// Types
+const (
+	ProviderNotValid                  = "ProviderNotValid"
+	ProviderSecretNotValid            = "ProviderSecretNotValid"
+	SourceProviderNotValid            = "SourceProviderNotValid"
+	SourceProviderSecretNotValid      = "SourceProviderSecretNotValid"
+	DestinationProviderNotValid       = "DestinationProviderNotValid"
+	DestinationProviderSecretNotValid = "DestinationProviderSecretNotValid"
+)
+
+//
+// Categories
+const (
+	Advisory = cnd.Advisory
+	Critical = cnd.Critical
+	Error    = cnd.Error
+	Warn     = cnd.Warn
+)
+
+// Reasons
+const (
+	NotSet       = "NotSet"
+	NotFound     = "NotFound"
+	TypeNotValid = "TypeNotValid"
+)
+
+// Statuses
+const (
+	True  = cnd.True
+	False = cnd.False
+)
+
+var (
+	ProviderInvNotReady = errors.New("provider inventory API not ready")
+)
+
+//
+// Provider validation.
+type Provider struct {
+	client.Client
+	// Found and populated by Validate().
+	Referenced *api.Provider
+}
+
+//
+// Validate a provider.
+func (r *Provider) Validate(ref core.ObjectReference) (result cnd.Conditions, err error) {
+	newCnd := cnd.Condition{
+		Type:     ProviderNotValid,
+		Status:   True,
+		Category: Critical,
+		Message:  "The provider is not valid.",
+	}
+	if !libref.RefSet(&ref) {
+		newCnd.Reason = NotSet
+		result.SetCondition(newCnd)
+		return
+	}
+	key := client.ObjectKey{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+	provider := api.Provider{}
+	err = r.Get(context.TODO(), key, &provider)
+	if k8serr.IsNotFound(err) {
+		err = nil
+		newCnd.Reason = NotFound
+		result.SetCondition(newCnd)
+		return
+	}
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	r.Referenced = &provider
+	newCnd = cnd.Condition{
+		Type:     ProviderSecretNotValid,
+		Status:   True,
+		Category: Critical,
+		Message:  "The provider secret is not valid.",
+	}
+	ref = provider.Spec.Secret
+	key = client.ObjectKey{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+	secret := core.Secret{}
+	err = r.Get(context.TODO(), key, &secret)
+	if k8serr.IsNotFound(err) {
+		err = nil
+		newCnd.Reason = NotFound
+		result.SetCondition(newCnd)
+		return
+	}
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	pClient, err := web.NewClient(provider)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	ready, err := pClient.Ready()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if !ready {
+		err = liberr.Wrap(ProviderInvNotReady)
+	}
+
+	return
+}
+
+//
+// ProviderPair
+type ProviderPair struct {
+	client.Client
+	// Found and populated by Validate().
+	Referenced struct {
+		Source      *api.Provider
+		Destination *api.Provider
+	}
+}
+
+//
+// Validate the pair.
+func (r *ProviderPair) Validate(pair api.ProviderPair) (result cnd.Conditions, err error) {
+	conditions, err := r.validateSource(pair)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	result.SetCondition(conditions.List...)
+	conditions, err = r.validateDestination(pair)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	result.SetCondition(conditions.List...)
+
+	return
+}
+
+//
+// Validate the source.
+func (r *ProviderPair) validateSource(pair api.ProviderPair) (result cnd.Conditions, err error) {
+	validation := Provider{Client: r.Client}
+	conditions, err := validation.Validate(pair.Source)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	// Remap the condition to be source oriented.
+	for _, newCnd := range conditions.List {
+		switch newCnd.Type {
+		case ProviderNotValid:
+			newCnd.Type = SourceProviderNotValid
+			newCnd.Message = "The source provider is not valid."
+		case ProviderSecretNotValid:
+			newCnd.Type = SourceProviderSecretNotValid
+			newCnd.Message = "The source provider secret is not valid."
+		default:
+			err = liberr.New("unknown")
+			return
+		}
+		result.SetCondition(newCnd)
+	}
+	// An openshift source is not supported.
+	r.Referenced.Source = validation.Referenced
+	if r.Referenced.Source != nil && r.Referenced.Source.Type() == api.OpenShift {
+		result.SetCondition(cnd.Condition{
+			Type:     SourceProviderNotValid,
+			Status:   True,
+			Reason:   TypeNotValid,
+			Category: Critical,
+			Message:  "The provider is not valid.",
+		})
+		return
+	}
+
+	return
+}
+
+//
+// Validate the destination.
+func (r *ProviderPair) validateDestination(pair api.ProviderPair) (result cnd.Conditions, err error) {
+	validation := Provider{Client: r.Client}
+	conditions, err := validation.Validate(pair.Destination)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	// Remap the condition to be destination oriented.
+	for _, newCnd := range conditions.List {
+		switch newCnd.Type {
+		case ProviderNotValid:
+			newCnd.Type = DestinationProviderNotValid
+			newCnd.Message = "The destination provider is not valid."
+		case ProviderSecretNotValid:
+			newCnd.Type = DestinationProviderSecretNotValid
+			newCnd.Message = "The destination provider secret is not valid."
+		default:
+			err = liberr.New("unknown")
+			return
+		}
+		result.SetCondition(newCnd)
+	}
+	// A non-openshift destination is not supported.
+	r.Referenced.Destination = validation.Referenced
+	if r.Referenced.Destination != nil && r.Referenced.Destination.Type() != api.OpenShift {
+		result.SetCondition(cnd.Condition{
+			Type:     DestinationProviderNotValid,
+			Status:   True,
+			Reason:   TypeNotValid,
+			Category: Critical,
+			Message:  "The destination provider is not valid.",
+		})
+		return
+	}
+
+	return
+}

--- a/pkg/controller/validation/storage.go
+++ b/pkg/controller/validation/storage.go
@@ -1,0 +1,157 @@
+package validation
+
+import (
+	cnd "github.com/konveyor/controller/pkg/condition"
+	liberr "github.com/konveyor/controller/pkg/error"
+	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/ocp"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//
+// Types
+const (
+	SourceStorageNotValid      = "SourceStorageNotValid"
+	DestinationStorageNotValid = "DestinationStorageNotValid"
+)
+
+//
+// Storage pair validation.
+type StoragePair struct {
+	client.Client
+	Provider struct {
+		Source      *api.Provider
+		Destination *api.Provider
+	}
+}
+
+//
+// Validate pairs.
+func (r *StoragePair) Validate(list []api.StoragePair) (result cnd.Conditions, err error) {
+	conditions, err := r.validateSource(list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	result.SetCondition(conditions.List...)
+	conditions, err = r.validateDestination(list)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	result.SetCondition(conditions.List...)
+
+	return
+}
+
+//
+// Validate source storage.
+func (r *StoragePair) validateSource(list []api.StoragePair) (result cnd.Conditions, err error) {
+	provider := r.Provider.Source
+	if provider == nil {
+		return
+	}
+	pClient, err := web.NewClient(*provider)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	notValid := []string{}
+	var resource interface{}
+	switch provider.Type() {
+	case api.OpenShift:
+		return
+	case api.VSphere:
+		resource = &vsphere.Datastore{}
+	default:
+		err = web.ProviderNotSupported
+		return
+	}
+	for _, entry := range list {
+		status, pErr := pClient.Get(resource, entry.Source.ID)
+		if pErr != nil {
+			err = liberr.Wrap(pErr)
+			return
+		}
+		switch status {
+		case http.StatusOK:
+		case http.StatusPartialContent:
+			err = liberr.Wrap(ProviderInvNotReady)
+			return
+		case http.StatusNotFound:
+			notValid = append(notValid, entry.Source.ID)
+		default:
+			err = liberr.New(http.StatusText(status))
+			return
+		}
+	}
+	if len(notValid) > 0 {
+		result.SetCondition(cnd.Condition{
+			Type:     SourceStorageNotValid,
+			Status:   True,
+			Reason:   NotFound,
+			Category: Critical,
+			Message:  "Source storage not valid.",
+		})
+	}
+
+	return
+}
+
+//
+// Validate destination storage.
+func (r *StoragePair) validateDestination(list []api.StoragePair) (result cnd.Conditions, err error) {
+	provider := r.Provider.Destination
+	if provider == nil {
+		return
+	}
+	pClient, err := web.NewClient(*provider)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	notValid := []string{}
+	var resource interface{}
+	switch provider.Type() {
+	case api.OpenShift:
+		resource = &ocp.StorageClass{}
+	case api.VSphere:
+		return
+	default:
+		err = web.ProviderNotSupported
+		return
+	}
+	for _, entry := range list {
+		name := entry.Destination.StorageClass
+		status, pErr := pClient.Get(resource, name)
+		if pErr != nil {
+			err = liberr.Wrap(pErr)
+			return
+		}
+		switch status {
+		case http.StatusOK:
+		case http.StatusPartialContent:
+			err = liberr.Wrap(ProviderInvNotReady)
+			return
+		case http.StatusNotFound:
+			notValid = append(notValid, entry.Source.ID)
+		default:
+			err = liberr.New(http.StatusText(status))
+			return
+		}
+	}
+	if len(notValid) > 0 {
+		result.SetCondition(cnd.Condition{
+			Type:     DestinationStorageNotValid,
+			Status:   True,
+			Reason:   NotFound,
+			Category: Critical,
+			Message:  "Destination storage not valid.",
+		})
+	}
+
+	return
+}

--- a/vendor/github.com/konveyor/controller/pkg/inventory/model/predicate.go
+++ b/vendor/github.com/konveyor/controller/pkg/inventory/model/predicate.go
@@ -144,7 +144,7 @@ type EqPredicate struct {
 func (p *EqPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	v, err := f.AsValue(p.Value)
 	if err != nil {
@@ -171,7 +171,7 @@ type NeqPredicate struct {
 func (p *NeqPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	v, err := f.AsValue(p.Value)
 	if err != nil {
@@ -198,7 +198,7 @@ type GtPredicate struct {
 func (p *GtPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	switch f.Value.Kind() {
 	case reflect.String,
@@ -237,7 +237,7 @@ type LtPredicate struct {
 func (p *LtPredicate) Build(options *ListOptions) error {
 	f, found := p.match(options.fields)
 	if !found {
-		return PredicateRefErr
+		return liberr.Wrap(PredicateRefErr)
 	}
 	switch f.Value.Kind() {
 	case reflect.String,

--- a/vendor/github.com/konveyor/controller/pkg/itinerary/simple.go
+++ b/vendor/github.com/konveyor/controller/pkg/itinerary/simple.go
@@ -1,6 +1,9 @@
 package itinerary
 
-import liberr "github.com/konveyor/controller/pkg/error"
+import (
+	"errors"
+	liberr "github.com/konveyor/controller/pkg/error"
+)
 
 //
 // List of steps.
@@ -47,7 +50,7 @@ type Itinerary struct {
 //
 // Errors.
 var (
-	StepNotFound = liberr.New("step not found")
+	StepNotFound = errors.New("step not found")
 )
 
 //
@@ -59,7 +62,7 @@ func (r *Itinerary) Get(name string) (step Step, err error) {
 		}
 	}
 
-	err = StepNotFound
+	err = liberr.Wrap(StepNotFound)
 	return
 }
 
@@ -74,7 +77,7 @@ func (r *Itinerary) First() (step Step, err error) {
 	if len(list) > 0 {
 		step = list[0]
 	} else {
-		err = StepNotFound
+		err = liberr.Wrap(StepNotFound)
 	}
 
 	return


### PR DESCRIPTION
Update network & storage map CRs to reference a _pair_ of source/destination providers.

Create new `validation` package under controller to support validating shared CR data structures:
- Provider (ref)
- ProviderPair (ref)
- NetworkPair
- StoragePair

Added `description` to the Plan CR.  Needed by the UI.
The _Message constants were, well, messy and since conditions only created in one place, I got rid of the __Message const.

Requires: https://github.com/konveyor/controller/pull/24