### PR TITLE
Fix datacenter properties missing on tree/host view.

### DIFF
--- a/pkg/controller/provider/web/vsphere/tree.go
+++ b/pkg/controller/provider/web/vsphere/tree.go
@@ -156,6 +156,7 @@ func (h TreeHandler) HostTree(ctx *gin.Context) {
 			return
 		}
 		r := Datacenter{}
+		r.With(&dc)
 		r.SelfLink = DatacenterHandler{}.Link(h.Provider, &dc)
 		branch.Kind = model.DatacenterKind
 		branch.Object = r


### PR DESCRIPTION
Fix datacenter properties missing on tree/host view.
```
{

    "kind": "Datacenter",
    "object": {
        "id": "",
        "parent": null,
        "name": "",
        "selfLink": "/namespaces/openshift-migration/providers/vsphere/test/datacenters/datacenter-2760"
    },
    "children": null
},
      
```

Fixed:

```
{
    "kind": "Datacenter",
    "object": {
        "id": "datacenter-2760",
        "parent": {
            "Kind": "Folder",
            "ID": "group-d1"
        },
        "name": "Fake_DC",
        "selfLink": "/namespaces/openshift-migration/providers/vsphere/test/datacenters/datacenter-2760"
    },
    "children": null
},
```


