### PR TITLE
API client improved.

### DIFF
--- a/pkg/controller/map/network/controller.go
+++ b/pkg/controller/map/network/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
 	"github.com/konveyor/virt-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -128,7 +129,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(mp)
 	if err != nil {
-		if errors.Is(err, ProviderInvNotReady) {
+		if errors.Is(err, web.ProviderNotReadyErr) {
 			return fastReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/map/network/validation.go
+++ b/pkg/controller/map/network/validation.go
@@ -32,12 +32,6 @@ const (
 )
 
 //
-// Errors
-var (
-	ProviderInvNotReady = validation.ProviderInvNotReady
-)
-
-//
 // Validate the mp resource.
 func (r *Reconciler) validate(mp *api.NetworkMap) error {
 	provider := validation.ProviderPair{Client: r}

--- a/pkg/controller/map/storage/controller.go
+++ b/pkg/controller/map/storage/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
 	"github.com/konveyor/virt-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -128,7 +129,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(mp)
 	if err != nil {
-		if errors.Is(err, ProviderInvNotReady) {
+		if errors.Is(err, web.ProviderNotReadyErr) {
 			return fastReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/map/storage/validation.go
+++ b/pkg/controller/map/storage/validation.go
@@ -32,12 +32,6 @@ const (
 )
 
 //
-// Errors
-var (
-	ProviderInvNotReady = validation.ProviderInvNotReady
-)
-
-//
 // Validate the mp resource.
 func (r *Reconciler) validate(mp *api.StorageMap) error {
 	provider := validation.ProviderPair{Client: r}

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
 	"github.com/konveyor/virt-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -145,7 +146,7 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	// Validations.
 	err = r.validate(plan)
 	if err != nil {
-		if errors.Is(err, ProviderInvNotReady) {
+		if errors.Is(err, web.ProviderNotReadyErr) {
 			return fastReQ, nil
 		}
 		log.Trace(err)

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -48,12 +48,6 @@ const (
 )
 
 //
-// Errors
-var (
-	ProviderInvNotReady = validation.ProviderInvNotReady
-)
-
-//
 // Validate the plan resource.
 func (r *Reconciler) validate(plan *api.Plan) error {
 	// Provider.
@@ -94,7 +88,7 @@ func (r *Reconciler) validateVM(provider *api.Provider, plan *api.Plan) error {
 	if provider == nil {
 		return nil
 	}
-	pClient, pErr := web.NewClient(*provider)
+	pClient, pErr := web.NewClient(provider)
 	if pErr != nil {
 		return liberr.Wrap(pErr)
 	}
@@ -105,7 +99,7 @@ func (r *Reconciler) validateVM(provider *api.Provider, plan *api.Plan) error {
 	case api.VSphere:
 		resource = &vsphere.VM{}
 	default:
-		return web.ProviderNotSupported
+		return liberr.Wrap(web.ProviderNotSupportedErr)
 	}
 	notValid := cnd.Condition{
 		Type:     VMNotValid,
@@ -124,8 +118,6 @@ func (r *Reconciler) validateVM(provider *api.Provider, plan *api.Plan) error {
 		}
 		switch status {
 		case http.StatusOK:
-		case http.StatusPartialContent:
-			return ProviderInvNotReady
 		case http.StatusNotFound:
 			notValid.Items = append(notValid.Items, vm.ID)
 		default:

--- a/pkg/controller/provider/web/client.go
+++ b/pkg/controller/provider/web/client.go
@@ -1,34 +1,20 @@
 package web
 
 import (
+	"errors"
+	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/ocp"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
+	"net/http"
+	"path"
 )
 
 var (
-	ProviderNotSupported = base.ProviderNotSupported
+	ProviderNotSupportedErr = errors.New("provider (type) not supported")
+	ProviderNotReadyErr     = errors.New("provider API not ready")
 )
-
-//
-// Build an appropriate client.
-func NewClient(provider api.Provider) (client Client, err error) {
-	switch provider.Type() {
-	case api.OpenShift:
-		client = &ocp.Client{
-			Provider: provider,
-		}
-	case api.VSphere:
-		client = &vsphere.Client{
-			Provider: provider,
-		}
-	default:
-		err = ProviderNotSupported
-	}
-
-	return
-}
 
 //
 // REST Client.
@@ -41,7 +27,114 @@ type Client interface {
 	// The `list` must be a pointer to a slice of resource object.
 	// Returns: The HTTP code and error.
 	List(list interface{}) (int, error)
-	// Get whether the provider is in inventory.
-	// Returns: True when found.
-	Ready() (bool, error)
+}
+
+//
+// Build an appropriate client.
+func NewClient(provider *api.Provider) (client Client, err error) {
+	switch provider.Type() {
+	case api.OpenShift:
+		client = &ProviderClient{
+			provider: provider,
+			Client: base.Client{
+				Resolver: &ocp.Resolver{Provider: provider},
+			},
+		}
+	case api.VSphere:
+		client = &ProviderClient{
+			provider: provider,
+			Client: base.Client{
+				Resolver: &vsphere.Resolver{Provider: provider},
+			},
+		}
+	default:
+		err = liberr.Wrap(ProviderNotSupportedErr)
+	}
+
+	return
+}
+
+//
+// Provider API client.
+type ProviderClient struct {
+	base.Client
+	// The provider.
+	provider *api.Provider
+}
+
+//
+// Get a resource.
+// Raises ProviderNotReadyErr on 404 and 206
+// when the provider is not yet in the inventory.
+func (r *ProviderClient) Get(resource interface{}, id string) (status int, err error) {
+	status, err = r.Client.Get(resource, id)
+	switch status {
+	case http.StatusNotFound:
+		ready := false
+		ready, err = r.Ready()
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		if !ready {
+			err = liberr.Wrap(ProviderNotReadyErr)
+		}
+	case http.StatusPartialContent:
+		err = liberr.Wrap(ProviderNotReadyErr)
+	}
+
+	return
+}
+
+//
+// List a resource collection.
+// Raises ProviderNotReadyErr on 404 and 206
+// when the provider is not yet in the inventory.
+func (r *ProviderClient) List(resource interface{}) (status int, err error) {
+	status, err = r.Client.List(resource)
+	switch status {
+	case http.StatusNotFound:
+		ready := false
+		ready, err = r.Ready()
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		if !ready {
+			err = liberr.Wrap(ProviderNotReadyErr)
+		}
+	case http.StatusPartialContent:
+		err = liberr.Wrap(ProviderNotReadyErr)
+	}
+
+	return
+}
+
+//
+// Get whether the provider is ready.has been inventoried.
+func (r *ProviderClient) Ready() (ready bool, err error) {
+	id := path.Join(
+		r.provider.Namespace,
+		r.provider.Name)
+	status := 0
+	switch r.provider.Type() {
+	case api.OpenShift:
+		status, err = r.Client.Get(&ocp.Provider{}, id)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		ready = status == http.StatusOK
+	case api.VSphere:
+		status, err = r.Client.Get(&vsphere.Provider{}, id)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		ready = status == http.StatusOK
+	default:
+		err = liberr.Wrap(ProviderNotSupportedErr)
+	}
+
+	return
 }

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -2,110 +2,28 @@ package ocp
 
 import (
 	liberr "github.com/konveyor/controller/pkg/error"
-	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
 	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
-	"net/http"
 	pathlib "path"
-	"reflect"
 	"strings"
 )
 
 //
-// Web client.
-type Client struct {
-	// Host <host>:<port>
-	Host string
-	// Provider
-	Provider api.Provider
-	// thin client
-	client base.Client
+// API path resolver.
+type Resolver struct {
+	*api.Provider
 }
 
 //
-// Get resources.
-func (c *Client) Get(resource interface{}, id string) (int, error) {
-	lv := reflect.ValueOf(resource)
-	switch lv.Kind() {
-	case reflect.Ptr:
-	default:
-		return -1, libmodel.MustBePtrErr
-	}
-	client := base.Client{
-		Host: c.Host,
-	}
-	path, err := c.Path(resource, id)
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-	status, err := client.Get(path, resource)
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-
-	return status, nil
-}
-
-//
-// List resources.
-func (c *Client) List(list interface{}) (int, error) {
-	var resource interface{}
-	lt := reflect.TypeOf(list)
-	lv := reflect.ValueOf(list)
-	switch lv.Kind() {
-	case reflect.Ptr:
-		lt := lt.Elem()
-		lv = lv.Elem()
-		switch lv.Kind() {
-		case reflect.Slice:
-			resource = reflect.New(lt.Elem()).Interface()
-		default:
-			return -1, libmodel.MustBeSlicePtrErr
-		}
-	default:
-		return -1, libmodel.MustBeSlicePtrErr
-	}
-	client := base.Client{
-		Host: c.Host,
-	}
-	path, err := c.Path(resource, "")
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-	status, err := client.Get(path, list)
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-
-	return status, nil
-}
-
-// Get whether the provider has been reconciled.
-func (c *Client) Ready() (found bool, err error) {
-	p := &Provider{}
-	id := pathlib.Join(
-		c.Provider.Namespace,
-		c.Provider.Name)
-	status, err := c.Get(p, id)
-	if err != nil {
-		return
-	}
-
-	found = status != http.StatusNotFound
-
-	return
-}
-
-//
-// Build the URL path.
-func (c *Client) Path(object interface{}, id string) (path string, err error) {
+// Resolve the URL path.
+func (r *Resolver) Path(object interface{}, id string) (path string, err error) {
 	ns, name := pathlib.Split(id)
 	ns = strings.TrimSuffix(ns, "/")
 	switch object.(type) {
 	case *Provider:
 		if id == "" { // list
-			ns = c.Provider.Namespace
+			ns = r.Provider.Namespace
 		}
 		h := ProviderHandler{}
 		path = h.Link(&model.Provider{
@@ -117,7 +35,7 @@ func (c *Client) Path(object interface{}, id string) (path string, err error) {
 	case *StorageClass:
 		h := StorageClassHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.StorageClass{
 				Base: model.Base{
 					Name: name,
@@ -125,11 +43,11 @@ func (c *Client) Path(object interface{}, id string) (path string, err error) {
 			})
 	case *NetworkAttachmentDefinition:
 		if id == "" { // list
-			ns = c.Provider.Namespace
+			ns = r.Provider.Namespace
 		}
 		h := NetworkAttachmentDefinitionHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.NetworkAttachmentDefinition{
 				Base: model.Base{
 					Namespace: ns,
@@ -137,7 +55,7 @@ func (c *Client) Path(object interface{}, id string) (path string, err error) {
 				},
 			})
 	default:
-		err = base.ResourceNotSupported
+		err = liberr.Wrap(base.ResourceNotResolvedErr)
 	}
 
 	return

--- a/pkg/controller/provider/web/vsphere/client.go
+++ b/pkg/controller/provider/web/vsphere/client.go
@@ -2,109 +2,29 @@ package vsphere
 
 import (
 	liberr "github.com/konveyor/controller/pkg/error"
-	libmodel "github.com/konveyor/controller/pkg/inventory/model"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
 	ocpmodel "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
 	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/vsphere"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
-	"net/http"
 	pathlib "path"
-	"reflect"
 	"strings"
 )
 
 //
-// Web client.
-type Client struct {
-	// Host <host>:<port>
-	Host string
-	// Provider
-	Provider api.Provider
-}
-
-//
-// Get a resource.
-func (c *Client) Get(resource interface{}, id string) (int, error) {
-	lv := reflect.ValueOf(resource)
-	switch lv.Kind() {
-	case reflect.Ptr:
-	default:
-		return -1, libmodel.MustBePtrErr
-	}
-	client := base.Client{
-		Host: c.Host,
-	}
-	path, err := c.Path(resource, id)
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-	status, err := client.Get(path, resource)
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-
-	return status, nil
-}
-
-//
-// List resources.
-func (c *Client) List(list interface{}) (int, error) {
-	var resource interface{}
-	lt := reflect.TypeOf(list)
-	lv := reflect.ValueOf(list)
-	switch lv.Kind() {
-	case reflect.Ptr:
-		lt := lt.Elem()
-		lv = lv.Elem()
-		switch lv.Kind() {
-		case reflect.Slice:
-			resource = reflect.New(lt.Elem()).Interface()
-		default:
-			return -1, libmodel.MustBeSlicePtrErr
-		}
-	default:
-		return -1, libmodel.MustBeSlicePtrErr
-	}
-	client := base.Client{
-		Host: c.Host,
-	}
-	path, err := c.Path(resource, "")
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-	status, err := client.Get(path, list)
-	if err != nil {
-		return -1, liberr.Wrap(err)
-	}
-
-	return status, nil
-}
-
-// Get whether the provider has been reconciled.
-func (c *Client) Ready() (found bool, err error) {
-	p := &Provider{}
-	id := pathlib.Join(
-		c.Provider.Namespace,
-		c.Provider.Name)
-	status, err := c.Get(p, id)
-	if err != nil {
-		return
-	}
-
-	found = status != http.StatusNotFound
-
-	return
+// API path resolver.
+type Resolver struct {
+	*api.Provider
 }
 
 //
 // Build the URL path.
-func (c *Client) Path(resource interface{}, id string) (path string, err error) {
+func (r *Resolver) Path(resource interface{}, id string) (path string, err error) {
 	switch resource.(type) {
 	case *Provider:
 		ns, name := pathlib.Split(id)
 		ns = strings.TrimSuffix(ns, "/")
 		if id == "" { // list
-			ns = c.Provider.Namespace
+			ns = r.Provider.Namespace
 		}
 		h := ProviderHandler{}
 		path = h.Link(
@@ -117,47 +37,47 @@ func (c *Client) Path(resource interface{}, id string) (path string, err error) 
 	case *Datacenter:
 		h := DatacenterHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.Datacenter{
 				Base: model.Base{ID: id},
 			})
 	case *Cluster:
 		h := ClusterHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.Cluster{
 				Base: model.Base{ID: id},
 			})
 	case *Host:
 		h := HostHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.Host{
 				Base: model.Base{ID: id},
 			})
 	case *Network:
 		h := NetworkHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.Network{
 				Base: model.Base{ID: id},
 			})
 	case *Datastore:
 		h := DatastoreHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.Datastore{
 				Base: model.Base{ID: id},
 			})
 	case *VM:
 		h := VMHandler{}
 		path = h.Link(
-			&c.Provider,
+			r.Provider,
 			&model.VM{
 				Base: model.Base{ID: id},
 			})
 	default:
-		err = base.ResourceNotSupported
+		err = liberr.Wrap(base.ResourceNotResolvedErr)
 	}
 
 	return

--- a/pkg/controller/validation/network.go
+++ b/pkg/controller/validation/network.go
@@ -62,7 +62,7 @@ func (r *NetworkPair) validateSource(list []api.NetworkPair) (result cnd.Conditi
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(*provider)
+	pClient, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -75,7 +75,7 @@ func (r *NetworkPair) validateSource(list []api.NetworkPair) (result cnd.Conditi
 	case api.VSphere:
 		resource = &vsphere.Network{}
 	default:
-		err = web.ProviderNotSupported
+		err = liberr.Wrap(web.ProviderNotSupportedErr)
 		return
 	}
 	for _, entry := range list {
@@ -86,9 +86,6 @@ func (r *NetworkPair) validateSource(list []api.NetworkPair) (result cnd.Conditi
 		}
 		switch status {
 		case http.StatusOK:
-		case http.StatusPartialContent:
-			err = liberr.Wrap(ProviderInvNotReady)
-			return
 		case http.StatusNotFound:
 			notValid = append(notValid, entry.Source.ID)
 		default:
@@ -116,7 +113,7 @@ func (r *NetworkPair) validateDestination(list []api.NetworkPair) (result cnd.Co
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(*provider)
+	pClient, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -130,7 +127,7 @@ func (r *NetworkPair) validateDestination(list []api.NetworkPair) (result cnd.Co
 	case api.VSphere:
 		return
 	default:
-		err = web.ProviderNotSupported
+		err = liberr.Wrap(web.ProviderNotSupportedErr)
 		return
 	}
 next:
@@ -149,9 +146,6 @@ next:
 			}
 			switch status {
 			case http.StatusOK:
-			case http.StatusPartialContent:
-				err = liberr.Wrap(ProviderInvNotReady)
-				return
 			case http.StatusNotFound:
 				notFound = append(notFound, entry.Source.ID)
 			default:

--- a/pkg/controller/validation/provider.go
+++ b/pkg/controller/validation/provider.go
@@ -2,12 +2,10 @@ package validation
 
 import (
 	"context"
-	"errors"
 	cnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
-	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,10 +42,6 @@ const (
 const (
 	True  = cnd.True
 	False = cnd.False
-)
-
-var (
-	ProviderInvNotReady = errors.New("provider inventory API not ready")
 )
 
 //
@@ -111,19 +105,6 @@ func (r *Provider) Validate(ref core.ObjectReference) (result cnd.Conditions, er
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
-	}
-	pClient, err := web.NewClient(provider)
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-	ready, err := pClient.Ready()
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-	if !ready {
-		err = liberr.Wrap(ProviderInvNotReady)
 	}
 
 	return

--- a/pkg/controller/validation/storage.go
+++ b/pkg/controller/validation/storage.go
@@ -54,7 +54,7 @@ func (r *StoragePair) validateSource(list []api.StoragePair) (result cnd.Conditi
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(*provider)
+	pClient, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -67,7 +67,7 @@ func (r *StoragePair) validateSource(list []api.StoragePair) (result cnd.Conditi
 	case api.VSphere:
 		resource = &vsphere.Datastore{}
 	default:
-		err = web.ProviderNotSupported
+		err = liberr.Wrap(web.ProviderNotSupportedErr)
 		return
 	}
 	for _, entry := range list {
@@ -78,9 +78,6 @@ func (r *StoragePair) validateSource(list []api.StoragePair) (result cnd.Conditi
 		}
 		switch status {
 		case http.StatusOK:
-		case http.StatusPartialContent:
-			err = liberr.Wrap(ProviderInvNotReady)
-			return
 		case http.StatusNotFound:
 			notValid = append(notValid, entry.Source.ID)
 		default:
@@ -108,7 +105,7 @@ func (r *StoragePair) validateDestination(list []api.StoragePair) (result cnd.Co
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(*provider)
+	pClient, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -121,7 +118,7 @@ func (r *StoragePair) validateDestination(list []api.StoragePair) (result cnd.Co
 	case api.VSphere:
 		return
 	default:
-		err = web.ProviderNotSupported
+		err = liberr.Wrap(web.ProviderNotSupportedErr)
 		return
 	}
 	for _, entry := range list {
@@ -133,9 +130,6 @@ func (r *StoragePair) validateDestination(list []api.StoragePair) (result cnd.Co
 		}
 		switch status {
 		case http.StatusOK:
-		case http.StatusPartialContent:
-			err = liberr.Wrap(ProviderInvNotReady)
-			return
 		case http.StatusNotFound:
 			notValid = append(notValid, entry.Source.ID)
 		default:


### PR DESCRIPTION
This de-duplicates a good bit of code in the `web/ocp` and `web/vsphere` packages by introducing the convent of a `Resolver`.
The _Resolver_ resolves a REST resource object (kind) into a URL path.  Resolving the path **was** the main reason that the _type-sepecific_ package had to implement their own Client.

The provider API _Ready_ functionality has been centralized in the `ProviderClient` and rather than being called specifically, the provider _readiness_ is check on 404.  This also elliminates race conditions between the client making the GET call and the provider controller add/delete from inventory.

This PR also reduces complexity everywhere the provider REST API client is used in the other controllers because they no longer need to check for 206 _PartialContent_ because the `ProviderClient` raises the appropriate error.