### PR TITLE
Add support for user selected target namespace.

### DIFF
--- a/config/crds/virt_v1alpha1_networkmap.yaml
+++ b/config/crds/virt_v1alpha1_networkmap.yaml
@@ -48,8 +48,6 @@ spec:
                         type: string
                     required:
                     - type
-                    - namespace
-                    - name
                     type: object
                   source:
                     description: Source network.

--- a/config/crds/virt_v1alpha1_plan.yaml
+++ b/config/crds/virt_v1alpha1_plan.yaml
@@ -82,8 +82,6 @@ spec:
                             type: string
                         required:
                         - type
-                        - namespace
-                        - name
                         type: object
                       source:
                         description: Source network.
@@ -114,6 +112,9 @@ spec:
               - source
               - destination
               type: object
+            targetNamespace:
+              description: Target namespace.
+              type: string
             vms:
               description: List of VMs.
               items:

--- a/pkg/apis/virt/v1alpha1/mapped/network.go
+++ b/pkg/apis/virt/v1alpha1/mapped/network.go
@@ -6,9 +6,9 @@ type DestinationNetwork struct {
 	// The network type (pod|multus)
 	Type string `json:"type"`
 	// The namespace (multus only).
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 	// The name.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 //

--- a/pkg/apis/virt/v1alpha1/plan.go
+++ b/pkg/apis/virt/v1alpha1/plan.go
@@ -28,6 +28,8 @@ import (
 type PlanSpec struct {
 	// Description
 	Description string `json:"description,omitempty"`
+	// Target namespace.
+	TargetNamespace string `json:"targetNamespace,omitempty"`
 	// Providers.
 	Provider ProviderPair `json:"provider"`
 	// Resource map.

--- a/pkg/controller/provider/container/ocp/reconciler.go
+++ b/pkg/controller/provider/container/ocp/reconciler.go
@@ -18,6 +18,7 @@ func New(db libmodel.DB, provider *api.Provider, secret *core.Secret) *libocp.Re
 		db,
 		provider,
 		secret,
+		&Namespace{},
 		&NetworkAttachmentDefinition{},
 		&StorageClass{})
 }

--- a/pkg/controller/provider/model/ocp/doc.go
+++ b/pkg/controller/provider/model/ocp/doc.go
@@ -18,5 +18,6 @@ func All() []interface{} {
 		&Provider{},
 		&NetworkAttachmentDefinition{},
 		&StorageClass{},
+		&Namespace{},
 	}
 }

--- a/pkg/controller/provider/model/ocp/model.go
+++ b/pkg/controller/provider/model/ocp/model.go
@@ -112,6 +112,12 @@ func (m *Provider) With(p *api.Provider) {
 }
 
 //
+// Namespace
+type Namespace struct {
+	Base
+}
+
+//
 // StorageClass
 type StorageClass struct {
 	Base

--- a/pkg/controller/provider/web/base/handler.go
+++ b/pkg/controller/provider/web/base/handler.go
@@ -106,7 +106,9 @@ func (h *Handler) setDetail(ctx *gin.Context) int {
 // Build link.
 func (h *Handler) Link(path string, params Params) string {
 	for k, v := range params {
-		path = strings.Replace(path, ":"+k, v, 1)
+		if len(v) > 0 {
+			path = strings.Replace(path, ":"+k, v, 1)
+		}
 	}
 
 	return path

--- a/pkg/controller/provider/web/ocp/client.go
+++ b/pkg/controller/provider/web/ocp/client.go
@@ -32,6 +32,15 @@ func (r *Resolver) Path(object interface{}, id string) (path string, err error) 
 				Name:      name,
 			},
 		})
+	case *Namespace:
+		h := NamespaceHandler{}
+		path = h.Link(
+			r.Provider,
+			&model.Namespace{
+				Base: model.Base{
+					Name: name,
+				},
+			})
 	case *StorageClass:
 		h := StorageClassHandler{}
 		path = h.Link(

--- a/pkg/controller/provider/web/ocp/doc.go
+++ b/pkg/controller/provider/web/ocp/doc.go
@@ -34,6 +34,11 @@ func Handlers(container *container.Container) []libweb.RequestHandler {
 				Container: container,
 			},
 		},
+		&NamespaceHandler{
+			Handler: base.Handler{
+				Container: container,
+			},
+		},
 		&StorageClassHandler{
 			Handler: base.Handler{
 				Container: container,

--- a/pkg/controller/provider/web/ocp/namespace.go
+++ b/pkg/controller/provider/web/ocp/namespace.go
@@ -1,0 +1,133 @@
+package ocp
+
+import (
+	"errors"
+	"github.com/gin-gonic/gin"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/base"
+	core "k8s.io/api/core/v1"
+	"net/http"
+)
+
+//
+// Routes.
+const (
+	Ns2Param       = "ns2"
+	NamespacesRoot = ProviderRoot + "/namespaces"
+	NamespaceRoot  = NamespacesRoot + "/:" + Ns2Param
+)
+
+//
+// Namespace handler.
+type NamespaceHandler struct {
+	Handler
+}
+
+//
+// Add routes to the `gin` router.
+func (h *NamespaceHandler) AddRoutes(e *gin.Engine) {
+	e.GET(NamespacesRoot, h.List)
+	e.GET(NamespacesRoot+"/", h.List)
+	e.GET(NamespaceRoot, h.Get)
+}
+
+//
+// List resources in a REST collection.
+func (h NamespaceHandler) List(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	db := h.Reconciler.DB()
+	list := []model.Namespace{}
+	err := db.List(
+		&list,
+		libmodel.ListOptions{
+			Page: &h.Page,
+		})
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	content := []interface{}{}
+	for _, m := range list {
+		r := &Namespace{}
+		r.With(&m)
+		r.SelfLink = h.Link(h.Provider, &m)
+		content = append(content, r.Content(h.Detail))
+	}
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Get a specific REST resource.
+func (h NamespaceHandler) Get(ctx *gin.Context) {
+	status := h.Prepare(ctx)
+	if status != http.StatusOK {
+		ctx.Status(status)
+		return
+	}
+	m := &model.Namespace{
+		Base: model.Base{
+			Name: ctx.Param(Ns2Param),
+		},
+	}
+	db := h.Reconciler.DB()
+	err := db.Get(m)
+	if errors.Is(err, model.NotFound) {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		Log.Trace(err)
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	r := &Namespace{}
+	r.With(m)
+	r.SelfLink = h.Link(h.Provider, m)
+	content := r.Content(true)
+
+	ctx.JSON(http.StatusOK, content)
+}
+
+//
+// Build self link (URI).
+func (h NamespaceHandler) Link(p *api.Provider, m *model.Namespace) string {
+	return h.Handler.Link(
+		NamespaceRoot,
+		base.Params{
+			base.NsParam:       p.Namespace,
+			base.ProviderParam: p.Name,
+			Ns2Param:           m.Name,
+		})
+}
+
+//
+// REST Resource.
+type Namespace struct {
+	Resource
+	Object interface{} `json:"object"`
+}
+
+//
+// Set fields with the specified object.
+func (r *Namespace) With(m *model.Namespace) {
+	r.Resource.With(&m.Base)
+	r.Object = m.DecodeObject(&core.Namespace{})
+}
+
+//
+// As content.
+func (r *Namespace) Content(detail bool) interface{} {
+	if !detail {
+		return r.Resource
+	}
+
+	return r
+}


### PR DESCRIPTION
Add `/namespaces` to provider inventory so the UI can list candidate target namespaces.
Add `Plan.Spec.TargetNamespace` as optional field.  This is where VMs will be migrated to.

Fixed issue:
- The _networkattachmentdefinitions_ `SelfLink` needs to be qualified by namespace.
- NetworkMap destination namespace & name not required when type=pod. 
- Fix (provider) API client to ensure that only URL params with values are replaced.  Else, the path will be missing segments with alters the path part of the URL in unpredictable ways.