### PR TITLE
Better support for hosts.

### DIFF
--- a/config/crds/virt_v1alpha1_host.yaml
+++ b/config/crds/virt_v1alpha1_host.yaml
@@ -40,6 +40,9 @@ spec:
             provider:
               description: Provider
               type: object
+            secret:
+              description: Credentials.
+              type: object
           required:
           - provider
           - id

--- a/config/crds/virt_v1alpha1_plan.yaml
+++ b/config/crds/virt_v1alpha1_plan.yaml
@@ -129,9 +129,6 @@ spec:
                         description: Pre-migration hook.
                         type: object
                     type: object
-                  host:
-                    description: Host
-                    type: object
                   id:
                     description: 'The VM identifier. For:   - vSphere: The managed
                       object ID.'

--- a/pkg/apis/virt/v1alpha1/host.go
+++ b/pkg/apis/virt/v1alpha1/host.go
@@ -33,6 +33,8 @@ type HostSpec struct {
 	ID string `json:"id"`
 	// IP address used for disk transfer.
 	IpAddress string `json:"ipAddress"`
+	// Credentials.
+	Secret core.ObjectReference `json:"secret,omitempty"`
 }
 
 //
@@ -55,6 +57,9 @@ type Host struct {
 	meta.ObjectMeta `json:"metadata,omitempty"`
 	Spec            HostSpec   `json:"spec,omitempty"`
 	Status          HostStatus `json:"status,omitempty"`
+	// Referenced resources populated
+	// during validation.
+	Referenced `json:"-"`
 }
 
 //

--- a/pkg/apis/virt/v1alpha1/plan.go
+++ b/pkg/apis/virt/v1alpha1/plan.go
@@ -20,7 +20,6 @@ import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1/plan"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 //
@@ -74,46 +73,6 @@ type Plan struct {
 	meta.ObjectMeta `json:"metadata,omitempty"`
 	Spec            PlanSpec   `json:"spec,omitempty"`
 	Status          PlanStatus `json:"status,omitempty"`
-}
-
-//
-// Generated name for kubevirt VM Import mapping CR.
-func (r *Plan) NameForMapping() string {
-	uid := string(r.GetUID())
-	parts := []string{
-		"plan",
-		r.Name,
-		uid[len(uid)-4:],
-	}
-
-	return strings.Join(parts, "-")
-}
-
-//
-// Generated name for kubevirt VM Import CR secret.
-func (r *Plan) NameForSecret() string {
-	uid := string(r.GetUID())
-	parts := []string{
-		"plan",
-		r.Name,
-		uid[len(uid)-4:],
-	}
-
-	return strings.Join(parts, "-")
-}
-
-//
-// Generated name for kubevirt VM Import CR.
-func (r *Plan) NameForImport(vmID string) string {
-	uid := string(r.Status.Migration.Active)
-	parts := []string{
-		"plan",
-		r.Name,
-		vmID,
-		uid[len(uid)-4:],
-	}
-
-	return strings.Join(parts, "-")
 }
 
 //

--- a/pkg/apis/virt/v1alpha1/plan/vm.go
+++ b/pkg/apis/virt/v1alpha1/plan/vm.go
@@ -1,9 +1,5 @@
 package plan
 
-import (
-	core "k8s.io/api/core/v1"
-)
-
 //
 // A VM listed on the plan.
 type VM struct {
@@ -13,8 +9,6 @@ type VM struct {
 	ID string `json:"id"`
 	// Enable hooks.
 	Hook *Hook `json:"hook,omitempty"`
-	// Host
-	Host *core.ObjectReference `json:"host,omitempty" ref:"Host"`
 }
 
 //

--- a/pkg/apis/virt/v1alpha1/plan/zz_generated.deepcopy.go
+++ b/pkg/apis/virt/v1alpha1/plan/zz_generated.deepcopy.go
@@ -215,11 +215,6 @@ func (in *VM) DeepCopyInto(out *VM) {
 		*out = new(Hook)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Host != nil {
-		in, out := &in.Host, &out.Host
-		*out = new(v1.ObjectReference)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/apis/virt/v1alpha1/referenced.go
+++ b/pkg/apis/virt/v1alpha1/referenced.go
@@ -1,0 +1,26 @@
+package v1alpha1
+
+import core "k8s.io/api/core/v1"
+
+//
+// Referenced resources.
+// Holds resources fetched during validation.
+// +k8s:deepcopy-gen=false
+type Referenced struct {
+	// Provider.
+	Provider struct {
+		Source      *Provider
+		Destination *Provider
+	}
+	// Secret.
+	Secret *core.Secret
+	// Plan
+	Plan *Plan
+}
+
+func (in *Referenced) DeepCopyInto(*Referenced) {
+}
+
+func (in *Referenced) DeepCopy() *Referenced {
+	return in
+}

--- a/pkg/apis/virt/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/virt/v1alpha1/zz_generated.deepcopy.go
@@ -32,6 +32,7 @@ func (in *Host) DeepCopyInto(out *Host) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	out.Spec = in.Spec
 	in.Status.DeepCopyInto(&out.Status)
+	in.Referenced.DeepCopyInto(&out.Referenced)
 	return
 }
 
@@ -90,6 +91,7 @@ func (in *HostList) DeepCopyObject() runtime.Object {
 func (in *HostSpec) DeepCopyInto(out *HostSpec) {
 	*out = *in
 	out.Provider = in.Provider
+	out.Secret = in.Secret
 	return
 }
 

--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -6,14 +6,22 @@ import (
 	liberr "github.com/konveyor/controller/pkg/error"
 	libref "github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
+	"github.com/konveyor/virt-controller/pkg/controller/validation"
+	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //
 // Types
 const (
-	ProviderNotValid = "ProviderNotValid"
+	HostNotValid   = "HostNotValid"
+	SecretNotValid = "SecretNotValid"
+	TypeNotValid   = "TypeNotValid"
+	IpNotValid     = "IpNotValid"
 )
 
 //
@@ -26,12 +34,16 @@ const (
 	Warn     = libcnd.Warn
 )
 
+//
 // Reasons
 const (
 	NotSet   = "NotSet"
 	NotFound = "NotFound"
+	DataErr  = "DataErr"
+	TypeErr  = "TypeErr"
 )
 
+//
 // Statuses
 const (
 	True  = libcnd.True
@@ -45,6 +57,18 @@ func (r *Reconciler) validate(host *api.Host) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
+	err = r.validateID(host)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	err = r.validateIp(host)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	err = r.validateSecret(host)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
 
 	return nil
 }
@@ -52,31 +76,154 @@ func (r *Reconciler) validate(host *api.Host) error {
 //
 // Validate provider field.
 func (r *Reconciler) validateProvider(host *api.Host) error {
-	ref := host.Spec.Provider
+	pVal := validation.Provider{
+		Client: r,
+	}
+	conditions, err := pVal.Validate(host.Spec.Provider)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	host.Status.UpdateConditions(conditions)
+	if pVal.Referenced == nil {
+		return nil
+	}
+	host.Referenced.Provider.Source = pVal.Referenced
+	switch pVal.Referenced.Type() {
+	case api.VSphere:
+	default:
+		host.Status.SetCondition(
+			libcnd.Condition{
+				Type:     TypeNotValid,
+				Status:   True,
+				Reason:   TypeErr,
+				Category: Critical,
+				Message:  "Provider type not supported.",
+			})
+	}
+
+	return nil
+}
+
+//
+// Validate host ID field.
+func (r *Reconciler) validateID(host *api.Host) error {
+	if host.Spec.ID == "" {
+		host.Status.SetCondition(
+			libcnd.Condition{
+				Type:     HostNotValid,
+				Status:   True,
+				Reason:   NotSet,
+				Category: Critical,
+				Message:  "The `id` is not valid.",
+			})
+		return nil
+	}
+	provider := host.Referenced.Provider.Source
+	if provider == nil {
+		return nil
+	}
+	inventory, err := web.NewClient(provider)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	var resource interface{}
+	switch provider.Type() {
+	case api.VSphere:
+		resource = &vsphere.Host{}
+	default:
+		return nil
+	}
+	status, err := inventory.Get(resource, host.Spec.ID)
+	if err != nil {
+		return liberr.Wrap(err)
+	}
+	if status != http.StatusOK {
+		host.Status.SetCondition(
+			libcnd.Condition{
+				Type:     HostNotValid,
+				Status:   True,
+				Reason:   NotFound,
+				Category: Critical,
+				Message:  "The `id` is not valid.",
+			})
+	}
+
+	return nil
+}
+
+//
+// Validate host ID field.
+func (r *Reconciler) validateIp(host *api.Host) error {
+	if host.Spec.IpAddress == "" {
+		host.Status.SetCondition(
+			libcnd.Condition{
+				Type:     IpNotValid,
+				Status:   True,
+				Reason:   NotSet,
+				Category: Critical,
+				Message:  "The `ipAddress` is not valid.",
+			})
+	}
+
+	return nil
+}
+
+//
+// Validate secret (ref).
+//   1. The references is complete.
+//   2. The secret exists.
+//   3. the content of the secret is valid.
+func (r *Reconciler) validateSecret(host *api.Host) error {
+	// NotSet
 	newCnd := libcnd.Condition{
-		Type:     ProviderNotValid,
+		Type:     SecretNotValid,
 		Status:   True,
 		Reason:   NotSet,
 		Category: Critical,
-		Message:  "The `provider` is not valid.",
+		Message:  "The `secret` is not valid.",
 	}
+	ref := host.Spec.Secret
 	if !libref.RefSet(&ref) {
 		host.Status.SetCondition(newCnd)
 		return nil
 	}
-	provider := &api.Provider{}
+	// NotFound
+	secret := &core.Secret{}
 	key := client.ObjectKey{
 		Namespace: ref.Namespace,
 		Name:      ref.Name,
 	}
-	err := r.Get(context.TODO(), key, provider)
+	err := r.Get(context.TODO(), key, secret)
 	if errors.IsNotFound(err) {
 		err = nil
 		newCnd.Reason = NotFound
 		host.Status.SetCondition(newCnd)
+		return nil
 	}
 	if err != nil {
 		return liberr.Wrap(err)
+	}
+	// DataErr
+	keyList := []string{}
+	provider := host.Referenced.Provider.Source
+	if provider != nil {
+		switch provider.Type() {
+		case api.VSphere:
+			keyList = []string{
+				"user",
+				"password",
+				"thumbprint",
+			}
+		}
+	}
+	for _, key := range keyList {
+		if _, found := secret.Data[key]; !found {
+			newCnd.Items = append(newCnd.Items, key)
+		}
+	}
+	if len(newCnd.Items) > 0 {
+		newCnd.Reason = DataErr
+		host.Status.SetCondition(newCnd)
 	}
 
 	return nil

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -1,31 +1,24 @@
 package plan
 
 import (
-	"context"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
-	"github.com/konveyor/controller/pkg/ref"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
 	"github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1/snapshot"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
 	"github.com/konveyor/virt-controller/pkg/controller/validation"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
-	"path"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //
 // Types
 const (
-	VMNotValid   = "VMNotValid"
-	DuplicateVM  = "DuplicateVM"
-	HostNotValid = "HostNotValid"
-	HookNotValid = "HookNotValid"
-	Executing    = "Executing"
-	Succeeded    = "Succeeded"
-	Failed       = "Failed"
+	VMNotValid  = "VMNotValid"
+	DuplicateVM = "DuplicateVM"
+	Executing   = "Executing"
+	Succeeded   = "Succeeded"
+	Failed      = "Failed"
 )
 
 //
@@ -104,7 +97,7 @@ func (r *Reconciler) validateVM(provider *api.Provider, plan *api.Plan) error {
 	if provider == nil {
 		return nil
 	}
-	pClient, pErr := web.NewClient(provider)
+	inventory, pErr := web.NewClient(provider)
 	if pErr != nil {
 		return liberr.Wrap(pErr)
 	}
@@ -141,7 +134,7 @@ func (r *Reconciler) validateVM(provider *api.Provider, plan *api.Plan) error {
 			notUnique.Items = append(notUnique.Items, vm.ID)
 			setOf[vm.ID] = true
 		}
-		status, pErr := pClient.Get(resource, vm.ID)
+		status, pErr := inventory.Get(resource, vm.ID)
 		if pErr != nil {
 			return liberr.Wrap(pErr)
 		}
@@ -158,39 +151,6 @@ func (r *Reconciler) validateVM(provider *api.Provider, plan *api.Plan) error {
 	}
 	if len(notUnique.Items) > 0 {
 		plan.Status.SetCondition(notUnique)
-	}
-	//
-	// Hosts referenced by VMs.
-	notValid = libcnd.Condition{
-		Type:     HostNotValid,
-		Status:   True,
-		Reason:   NotFound,
-		Category: Critical,
-		Message:  "Host referenced by VM not valid.",
-		Items:    []string{},
-	}
-	for _, vm := range plan.Spec.VMs {
-		if !ref.RefSet(vm.Host) {
-			continue
-		}
-		host := &api.Host{}
-		key := client.ObjectKey{
-			Namespace: vm.Host.Namespace,
-			Name:      vm.Host.Name,
-		}
-		err := r.Get(context.TODO(), key, host)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				notValid.Items = append(
-					notValid.Items, path.Join(key.Namespace, key.Name))
-				continue
-			} else {
-				return liberr.Wrap(err)
-			}
-		}
-	}
-	if len(notValid.Items) > 0 {
-		plan.Status.SetCondition(notValid)
 	}
 
 	return nil

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -438,6 +438,10 @@ func (v *VmAdapter) Apply(u types.ObjectUpdate) {
 				if n, cast := p.Val.(int32); cast {
 					v.model.BalloonedMemory = n
 				}
+			case fRuntimeHost:
+				ref := Ref{}
+				ref.With(p.Val)
+				v.model.Host = ref.Encode()
 			case fVmIpAddress:
 				if s, cast := p.Val.(string); cast {
 					v.model.IpAddress = s

--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -86,6 +86,7 @@ const (
 	fGuestName           = "summary.config.guestFullName"
 	fBalloonedMemory     = "summary.quickStats.balloonedMemory"
 	fVmIpAddress         = "summary.guest.ipAddress"
+	fRuntimeHost         = "runtime.host"
 )
 
 //
@@ -555,6 +556,7 @@ func (r *Reconciler) propertySpec() []types.PropertySpec {
 				fVmIpAddress,
 				fDatastore,
 				fNetwork,
+				fRuntimeHost,
 			},
 		},
 	}

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -168,6 +168,7 @@ type VM struct {
 	IpAddress           string `sql:""`
 	Disks               string `sql:""`
 	Networks            string `sql:""`
+	Host                string `sql:""`
 	Concerns            string `sql:""`
 }
 

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -126,6 +126,7 @@ type VM struct {
 	IpAddress           string          `json:"ipAddress"`
 	Networks            model.RefList   `json:"networks"`
 	Disks               []model.Disk    `json:"disks"`
+	Host                model.Ref       `json:"host"`
 	Concerns            []model.Concern `json:"concerns"`
 }
 
@@ -147,6 +148,7 @@ func (r *VM) With(m *model.VM) {
 	r.IpAddress = m.IpAddress
 	r.Networks = *model.RefListPtr().With(m.Networks)
 	r.Disks = m.DecodeDisks()
+	r.Host = *(&model.Ref{}).With(m.Host)
 	r.Concerns = m.DecodeConcerns()
 	// TODO: EXAMPLE FOR UI DEV --REMOVE THIS.
 	r.Concerns = append(

--- a/pkg/controller/validation/network.go
+++ b/pkg/controller/validation/network.go
@@ -63,7 +63,7 @@ func (r *NetworkPair) validateSource(list []mapped.NetworkPair) (result libcnd.C
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(provider)
+	inventory, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -80,7 +80,7 @@ func (r *NetworkPair) validateSource(list []mapped.NetworkPair) (result libcnd.C
 		return
 	}
 	for _, entry := range list {
-		status, pErr := pClient.Get(resource, entry.Source.ID)
+		status, pErr := inventory.Get(resource, entry.Source.ID)
 		if pErr != nil {
 			err = liberr.Wrap(pErr)
 			return
@@ -114,7 +114,7 @@ func (r *NetworkPair) validateDestination(list []mapped.NetworkPair) (result lib
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(provider)
+	inventory, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -140,7 +140,7 @@ next:
 			id := path.Join(
 				entry.Destination.Namespace,
 				entry.Destination.Name)
-			status, pErr := pClient.Get(resource, id)
+			status, pErr := inventory.Get(resource, id)
 			if pErr != nil {
 				err = liberr.Wrap(pErr)
 				return

--- a/pkg/controller/validation/storage.go
+++ b/pkg/controller/validation/storage.go
@@ -55,7 +55,7 @@ func (r *StoragePair) validateSource(list []mapped.StoragePair) (result libcnd.C
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(provider)
+	inventory, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -72,7 +72,7 @@ func (r *StoragePair) validateSource(list []mapped.StoragePair) (result libcnd.C
 		return
 	}
 	for _, entry := range list {
-		status, pErr := pClient.Get(resource, entry.Source.ID)
+		status, pErr := inventory.Get(resource, entry.Source.ID)
 		if pErr != nil {
 			err = liberr.Wrap(pErr)
 			return
@@ -107,7 +107,7 @@ func (r *StoragePair) validateDestination(list []mapped.StoragePair) (result lib
 	if provider == nil {
 		return
 	}
-	pClient, err := web.NewClient(provider)
+	inventory, err := web.NewClient(provider)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -125,7 +125,7 @@ func (r *StoragePair) validateDestination(list []mapped.StoragePair) (result lib
 	}
 	for _, entry := range list {
 		name := entry.Destination.StorageClass
-		status, pErr := pClient.Get(resource, name)
+		status, pErr := inventory.Get(resource, name)
 		if pErr != nil {
 			err = liberr.Wrap(pErr)
 			return


### PR DESCRIPTION
Add `Secret` ref to `Host` CR.
Add `Host` validations.  Refactor to use shared provider validation.
Update controller flow to find Hosts in the same namespace and use the secret instead of the provider secret when found.  The logic also changed to create a Secret for each VirtualMachineImport CR.  Ideally we could create only the secrets needed but saving that for a future optimization.
Add VM.Host to the provider inventory.
Renamed and standardized variable for the provider API (as inventory) to clarify between that client and the k8s client.

Added `Referenced` object to be included in our CRs used to collect instances of resources fetched by validation to be used further downstream in reconcile logic.  The intent is to replace the stashing of resources in the Plan annotations in a follow up PR.
