### PR TITLE
Replace plan snapshot with Referenced.

### DIFF
--- a/pkg/apis/virt/v1alpha1/plan.go
+++ b/pkg/apis/virt/v1alpha1/plan.go
@@ -73,6 +73,9 @@ type Plan struct {
 	meta.ObjectMeta `json:"metadata,omitempty"`
 	Spec            PlanSpec   `json:"spec,omitempty"`
 	Status          PlanStatus `json:"status,omitempty"`
+	// Referenced resources populated
+	// during validation.
+	Referenced `json:"-"`
 }
 
 //

--- a/pkg/apis/virt/v1alpha1/snapshot/annotation.go
+++ b/pkg/apis/virt/v1alpha1/snapshot/annotation.go
@@ -85,7 +85,7 @@ func (r *Annotation) Get(key string, object interface{}) (err error) {
 //
 // Contains key.
 func (r *Annotation) Contains(key string) (found bool) {
-	_, found = r.GetAnnotations()[key]
+	_, found = r.GetAnnotations()[r.key(key)]
 	return
 }
 

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -4,7 +4,6 @@ import (
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
 	api "github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1"
-	"github.com/konveyor/virt-controller/pkg/apis/virt/v1alpha1/snapshot"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web/vsphere"
 	"github.com/konveyor/virt-controller/pkg/controller/validation"
@@ -82,11 +81,9 @@ func (r *Reconciler) validate(plan *api.Plan) error {
 	if err != nil {
 		return liberr.Wrap(err)
 	}
-	// Snapshot resources.
-	sn := snapshot.New(plan)
-	sn.Set(api.SourceSnapshot, provider.Referenced.Source)
-	sn.Set(api.DestinationSnapshot, provider.Referenced.Destination)
-	sn.Set(api.MapSnapshot, plan.Spec.Map)
+
+	plan.Referenced.Provider.Source = provider.Referenced.Source
+	plan.Referenced.Provider.Destination = provider.Referenced.Destination
 
 	return nil
 }


### PR DESCRIPTION
Replace plan snapshot with Referenced.
Also, noticed while troubleshooting that storing the validation result before running the migration would be helpful.  This should be safe since the Running, Succeeded, Failed conditions are durable.  Otherwise, if an error occurs while running the migration, the Plan will not reflect `Ready`.