### PR TITLE
Persist the VM name after migration

### DIFF
--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -180,6 +180,29 @@ func (r *Builder) Source(vmID string, object *vmio.VirtualMachineImportSourceSpe
 }
 
 //
+// Build the VMIO Target VM Name.
+func (r *Builder) TargetVmName(vmId string, object *vmio.VirtualMachineImportSourceSpec) (err error) {
+	vm := &vsphere.VM{}
+	status, pErr := r.Inventory.Get(vm, vmID)
+	if pErr != nil {
+		err = liberr.Wrap(pErr)
+		return
+	}
+	switch status {
+	case http.StatusOK:
+		object.targetVmName = vm.Name
+	default:
+		err = liberr.New(
+			fmt.Sprintf(
+				"VM %s lookup failed: %s",
+				vmID,
+				http.StatusText(status)))
+	}
+
+	return
+}
+
+//
 // Build tasks.
 func (r *Builder) Tasks(vmID string) (list []*plan.Task, err error) {
 	vm := &vsphere.VM{}

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -196,6 +196,10 @@ func (r *KubeVirt) buildImport(vmID string) (object *vmio.VirtualMachineImport, 
 	if err != nil {
 		return
 	}
+	targetVmName, err := r.BuildTargetVmName(vmID)
+	if err != nil {
+		return
+	}
 	namespace := r.namespace()
 	object = &vmio.VirtualMachineImport{
 		ObjectMeta: meta.ObjectMeta{
@@ -277,6 +281,18 @@ func (r *KubeVirt) buildSecret(vmID string) (object *core.Secret, err error) {
 func (r *KubeVirt) buildSource(vmID string) (object *vmio.VirtualMachineImportSourceSpec, err error) {
 	object = &vmio.VirtualMachineImportSourceSpec{}
 	err = r.Builder.Source(vmID, object)
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+
+	return
+}
+
+//
+// Build the VMIO TargetVmName.
+func (r *KubeVirt) buildTargetVmName(vmID string) (object *vmio.VirtualMachineImportSourceSpec, err error) {
+	object = &vmio.VirtualMachineImportSourceSpec{}
+	err = r.Builder.TargetVmName(vmID, object)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}


### PR DESCRIPTION
This pull request persists the VM name after migration. It simply sets the `targetVmName` attribute of the `VirtualMachineImport` CR to the name of the source VM. Otherwise, the name of the VM will be the operating system followed be a random string, which is not user friendly.