### PR TITLE
Update plan to reflect progress as needed in execute().

### DIFF
--- a/pkg/apis/virt/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/virt/v1alpha1/zz_generated.deepcopy.go
@@ -336,6 +336,7 @@ func (in *Plan) DeepCopyInto(out *Plan) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
+	in.Referenced.DeepCopyInto(&out.Referenced)
 	return
 }
 

--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -45,8 +45,8 @@ func (r *Builder) Secret(vmID string, in, object *core.Secret) (err error) {
 	if hostFound {
 		hostURL := liburl.URL{
 			Scheme: "https",
-			Host: host.Spec.IpAddress,
-			Path: vim25.Path,
+			Host:   host.Spec.IpAddress,
+			Path:   vim25.Path,
 		}
 		hostSecret, nErr := r.hostSecret(host)
 		if nErr != nil {

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -189,12 +189,8 @@ func (r *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 
 	//
 	// Execute.
+	// The plan is updated as needed to reflect status.
 	reQ, err := r.execute(plan)
-	if err != nil {
-		log.Trace(err)
-		return fastReQ, nil
-	}
-	err = r.Status().Update(context.TODO(), plan)
 	if err != nil {
 		log.Trace(err)
 		return fastReQ, nil
@@ -252,6 +248,10 @@ func (r *Reconciler) execute(plan *api.Plan) (reQ time.Duration, err error) {
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
+	}
+	err = r.Status().Update(context.TODO(), plan)
+	if err != nil {
+		err = liberr.Wrap(err)
 	}
 	if len(list) > 1 && reQ == 0 {
 		reQ = FastReQ


### PR DESCRIPTION
Moved the plan update (to reflect progress) to execute() so the plan is not double updated unnecessarily.