### PR TITLE
Propagate VM target name.

### DIFF
--- a/pkg/apis/virt/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/virt/v1alpha1/zz_generated.deepcopy.go
@@ -336,6 +336,7 @@ func (in *Plan) DeepCopyInto(out *Plan) {
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
+	in.Referenced.DeepCopyInto(&out.Referenced)
 	return
 }
 

--- a/pkg/controller/plan/builder/doc.go
+++ b/pkg/controller/plan/builder/doc.go
@@ -20,8 +20,8 @@ type Builder interface {
 	Secret(vmID string, in, object *core.Secret) (err error)
 	// Build VMIO resource mapping.
 	Mapping(mp *plan.Map, object *vmio.ResourceMapping) error
-	// Build VMIO import source.
-	Source(vmID string, object *vmio.VirtualMachineImportSourceSpec) error
+	// Build VMIO import spec.
+	Import(vmID string, object *vmio.VirtualMachineImportSpec) error
 	// Build tasks.
 	Tasks(vmID string) ([]*plan.Task, error)
 }

--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -45,8 +45,8 @@ func (r *Builder) Secret(vmID string, in, object *core.Secret) (err error) {
 	if hostFound {
 		hostURL := liburl.URL{
 			Scheme: "https",
-			Host: host.Spec.IpAddress,
-			Path: vim25.Path,
+			Host:   host.Spec.IpAddress,
+			Path:   vim25.Path,
 		}
 		hostSecret, nErr := r.hostSecret(host)
 		if nErr != nil {
@@ -152,8 +152,8 @@ func (r *Builder) Mapping(mp *plan.Map, object *vmio.ResourceMapping) (err error
 }
 
 //
-// Build the VMIO VM Source.
-func (r *Builder) Source(vmID string, object *vmio.VirtualMachineImportSourceSpec) (err error) {
+// Build the VMIO VM Import Spec.
+func (r *Builder) Import(vmID string, object *vmio.VirtualMachineImportSpec) (err error) {
 	vm := &vsphere.VM{}
 	status, pErr := r.Inventory.Get(vm, vmID)
 	if pErr != nil {
@@ -163,7 +163,8 @@ func (r *Builder) Source(vmID string, object *vmio.VirtualMachineImportSourceSpe
 	switch status {
 	case http.StatusOK:
 		uuid := vm.UUID
-		object.Vmware = &vmio.VirtualMachineImportVmwareSourceSpec{
+		object.TargetVMName = &vm.Name
+		object.Source.Vmware = &vmio.VirtualMachineImportVmwareSourceSpec{
 			VM: vmio.VirtualMachineImportVmwareSourceVMSpec{
 				ID: &uuid,
 			},


### PR DESCRIPTION
Propagate VM target name from the source provider.
Given the need for provider _type_ content in the VirtualMachineImportSpec, I think it makes sense to rename the Builder.Source() to Builder.Import() and broaden its scope.  This would be better than adding an additional method to the `Builder` interface because it's simpler and supports more future needs.