### PR TITLE
Add thumbprint to Host model

### DIFF
--- a/config/crds/virt_v1alpha1_host.yaml
+++ b/config/crds/virt_v1alpha1_host.yaml
@@ -37,6 +37,9 @@ spec:
             ipAddress:
               description: IP address used for disk transfer.
               type: string
+            thumbprint:
+              description: Certificate SHA-1 fingerprint, called thumbprint by VMware.
+              type: string
             provider:
               description: Provider
               type: object

--- a/pkg/apis/virt/v1alpha1/host.go
+++ b/pkg/apis/virt/v1alpha1/host.go
@@ -33,6 +33,8 @@ type HostSpec struct {
 	ID string `json:"id"`
 	// IP address used for disk transfer.
 	IpAddress string `json:"ipAddress"`
+	// Certificate SHA-1 fingerprint. Usually call thumbprint.
+	Thumbprint string `json:"thumbprint"`
 	// Credentials.
 	Secret core.ObjectReference `json:"secret,omitempty"`
 }

--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -285,6 +285,10 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 				if s, cast := p.Val.(string); cast {
 					v.model.ProductVersion = s
 				}
+			case fThumbprint:
+				if s, cast := p.Val.(string); cast {
+					v.model.Thumbprint = s
+				}
 			case fNetwork:
 				refList := RefList{}
 				refList.With(p.Val)

--- a/pkg/controller/provider/container/vsphere/reconciler.go
+++ b/pkg/controller/provider/container/vsphere/reconciler.go
@@ -65,6 +65,7 @@ const (
 	fProductName    = "config.product.name"
 	fProductVersion = "config.product.version"
 	fInMaintMode    = "summary.runtime.inMaintenanceMode"
+	fThumbprint     = "summary.config.sslThumbprint"
 	// Network
 	fTag = "tag"
 	// Datastore
@@ -511,6 +512,7 @@ func (r *Reconciler) propertySpec() []types.PropertySpec {
 				fProductName,
 				fProductVersion,
 				fInMaintMode,
+				fThumbprint,
 				fDatastore,
 				fNetwork,
 				fVm,

--- a/pkg/controller/provider/model/vsphere/model.go
+++ b/pkg/controller/provider/model/vsphere/model.go
@@ -134,6 +134,7 @@ type Host struct {
 	InMaintenanceMode bool   `sql:""`
 	ProductName       string `sql:""`
 	ProductVersion    string `sql:""`
+	Thumbprint        string `sql:""`
 	Networks          string `sql:""`
 	Datastores        string `sql:""`
 	Vms               string `sql:""`

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -115,7 +115,7 @@ type Host struct {
 	InMaintenanceMode bool          `json:"inMaintenance"`
 	ProductName       string        `json:"productName"`
 	ProductVersion    string        `json:"productVersion"`
-	Thumbprint        string        `json:thumbprint`
+	Thumbprint        string        `json:"thumbprint"`
 	Networks          model.RefList `json:"networks"`
 	Datastores        model.RefList `json:"datastores"`
 	VMs               model.RefList `json:"vms"`

--- a/pkg/controller/provider/web/vsphere/host.go
+++ b/pkg/controller/provider/web/vsphere/host.go
@@ -115,6 +115,7 @@ type Host struct {
 	InMaintenanceMode bool          `json:"inMaintenance"`
 	ProductName       string        `json:"productName"`
 	ProductVersion    string        `json:"productVersion"`
+	Thumbprint        string        `json:thumbprint`
 	Networks          model.RefList `json:"networks"`
 	Datastores        model.RefList `json:"datastores"`
 	VMs               model.RefList `json:"vms"`
@@ -127,6 +128,7 @@ func (r *Host) With(m *model.Host) {
 	r.InMaintenanceMode = m.InMaintenanceMode
 	r.ProductVersion = m.ProductVersion
 	r.ProductName = m.ProductName
+	r.Thumbprint = m.Thumbprint
 	r.Networks = *model.RefListPtr().With(m.Networks)
 	r.Datastores = *model.RefListPtr().With(m.Datastores)
 	r.VMs = *model.RefListPtr().With(m.Vms)


### PR DESCRIPTION
This pull request adds the `thumbprint` attribute to the Host model.
The data is collected from VMware via `MOR:HostSystem.summary.config.sslThumbprint`.