### PR TITLE
Provider inventory iteration 8

### DIFF
--- a/pkg/controller/host/validation.go
+++ b/pkg/controller/host/validation.go
@@ -212,7 +212,6 @@ func (r *Reconciler) validateSecret(host *api.Host) error {
 			keyList = []string{
 				"user",
 				"password",
-				"thumbprint",
 			}
 		}
 	}

--- a/pkg/controller/provider/model/vsphere/doc.go
+++ b/pkg/controller/provider/model/vsphere/doc.go
@@ -23,6 +23,7 @@ func All() []interface{} {
 		&Datacenter{},
 		&Cluster{},
 		&Network{},
+		&DVSwitch{},
 		&Datastore{},
 		&Host{},
 		&VM{},

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -112,22 +112,25 @@ func (h VMHandler) Link(p *api.Provider, m *model.VM) string {
 // REST Resource.
 type VM struct {
 	Resource
-	UUID                string          `json:"uuid"`
-	Firmware            string          `json:"firmware"`
-	CpuAffinity         []int32         `json:"cpuAffinity"`
-	CpuHotAddEnabled    bool            `json:"cpuHostAddEnabled"`
-	CpuHotRemoveEnabled bool            `json:"cpuHostRemoveEnabled"`
-	MemoryHotAddEnabled bool            `json:"memoryHotAddEnabled"`
-	CpuCount            int32           `json:"cpuCount"`
-	CoresPerSocket      int32           `json:"coresPerSocket"`
-	MemoryMB            int32           `json:"memoryMB"`
-	GuestName           string          `json:"guestName"`
-	BalloonedMemory     int32           `json:"balloonedMemory"`
-	IpAddress           string          `json:"ipAddress"`
-	Networks            model.RefList   `json:"networks"`
-	Disks               []model.Disk    `json:"disks"`
-	Host                model.Ref       `json:"host"`
-	Concerns            []model.Concern `json:"concerns"`
+	UUID                  string          `json:"uuid"`
+	Firmware              string          `json:"firmware"`
+	CpuAffinity           []int32         `json:"cpuAffinity"`
+	CpuHotAddEnabled      bool            `json:"cpuHostAddEnabled"`
+	CpuHotRemoveEnabled   bool            `json:"cpuHostRemoveEnabled"`
+	MemoryHotAddEnabled   bool            `json:"memoryHotAddEnabled"`
+	FaultToleranceEnabled bool            `json:"faultToleranceEnabled"`
+	CpuCount              int32           `json:"cpuCount"`
+	CoresPerSocket        int32           `json:"coresPerSocket"`
+	MemoryMB              int32           `json:"memoryMB"`
+	GuestName             string          `json:"guestName"`
+	BalloonedMemory       int32           `json:"balloonedMemory"`
+	IpAddress             string          `json:"ipAddress"`
+	StorageUsed           int64           `json:"storageUsed"`
+	SriovSupported        bool            `json:"sriovSupported"`
+	Networks              model.RefList   `json:"networks"`
+	Disks                 []model.Disk    `json:"disks"`
+	Host                  model.Ref       `json:"host"`
+	Concerns              []model.Concern `json:"concerns"`
 }
 
 //
@@ -146,6 +149,9 @@ func (r *VM) With(m *model.VM) {
 	r.GuestName = m.GuestName
 	r.BalloonedMemory = m.BalloonedMemory
 	r.IpAddress = m.IpAddress
+	r.StorageUsed = m.StorageUsed
+	r.FaultToleranceEnabled = m.FaultToleranceEnabled
+	r.SriovSupported = m.SriovSupported
 	r.Networks = *model.RefListPtr().With(m.Networks)
 	r.Disks = m.DecodeDisks()
 	r.Host = *(&model.Ref{}).With(m.Host)


### PR DESCRIPTION
Focused mostly on Host and some VM properties.
VM:
- disk storage used.
- fault tolerance enabled.
- has SRIOV support.
- shared (each disk).

Host:
- thumbprint
- cpuSocket
- cpuCores
- list of network adapters with (name, mtu, linkspeed) as candidate networks for disk transfer.

Add support for distributed virtual PortGroup & Swtich in the inventory and incorporate when deriving the Host adapter list used as candidates for disk transfer networks.

Also:
- Inject thumbprint on Host (in inventory) in VMIO secret when Host CR is matched.
- Host secret validation no longer requires _thumbprint_.
- Fix host controller logging _ProviderNotFound_ error (routine).

closes #36 
closes #48 
closes #49 
closes #65