### PR TITLE
Fix NAD selfLink.

### DIFF
--- a/pkg/controller/provider/web/ocp/netattachdefinition.go
+++ b/pkg/controller/provider/web/ocp/netattachdefinition.go
@@ -140,7 +140,7 @@ func (h NetworkAttachmentDefinitionHandler) Link(p *api.Provider, m *model.Netwo
 		base.Params{
 			base.NsParam:                     p.Namespace,
 			base.ProviderParam:               p.Name,
-			Ns2Param:                         p.Namespace,
+			Ns2Param:                         m.Namespace,
 			NetworkAttachmentDefinitionParam: m.Name,
 		})
 }


### PR DESCRIPTION
The NetworkAttachmentDefinition (NAD) `SelfLink` is constructed using the provider namespace instead of the NAD resource namespace.  As a result, the plan controller (using the client) is looking in the wrong namespace which results in NotFound validation condition.