### PR TITLE
Fixed SEGV caused when pNIC.LinkSpeed is nil.

### DIFF
--- a/pkg/controller/provider/container/vsphere/model.go
+++ b/pkg/controller/provider/container/vsphere/model.go
@@ -340,11 +340,15 @@ func (v *HostAdapter) Apply(u types.ObjectUpdate) {
 				if array, cast := p.Val.(types.ArrayOfPhysicalNic); cast {
 					network := v.model.DecodeNetwork()
 					for _, nic := range array.PhysicalNic {
+						linkSpeed := int32(0)
+						if nic.LinkSpeed != nil {
+							linkSpeed = nic.LinkSpeed.SpeedMb
+						}
 						network.PNICs = append(
 							network.PNICs,
 							model.PNIC{
 								Key:       nic.Key,
-								LinkSpeed: nic.Spec.LinkSpeed.SpeedMb,
+								LinkSpeed: linkSpeed,
 							})
 					}
 					sort.Slice(


### PR DESCRIPTION
Fixed SEGV caused when pNIC.LinkSpeed is nil.
```
goroutine 592 [running]:
github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere.(*HostAdapter).Apply(0xc002637080, 0xc0027038f0, 0x5, 0xc002703920, 0xa, 0xc002703940, 0x6, 0xc002714600, 0xf, 0x10, ...)
	/opt/app-root/src/github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere/model.go:347 +0x60e
github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere.Reconciler.applyEnter(0xc000b67a80, 0x31, 0xc0000fc8c0, 0xc000b788c0, 0x1de1d60, 0xc0016906e0, 0x1dd2ec0, 0xc00176dd20, 0xc0009fddc8, 0x8, ...)
	/opt/app-root/src/github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere/reconciler.go:716 +0xaf
github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere.(*Reconciler).apply(0xc000128cb0, 0x1dca8e0, 0xc000a985c0, 0xc0027e6000, 0x46, 0x80, 0x0, 0x0)
	/opt/app-root/src/github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere/reconciler.go:609 +0x26e
github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere.(*Reconciler).getUpdates(0xc000128cb0, 0x1dca8e0, 0xc000a985c0, 0x0, 0x0)
	/opt/app-root/src/github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere/reconciler.go:382 +0x693
github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere.(*Reconciler).Start.func1()
	/opt/app-root/src/github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere/reconciler.go:298 +0x199
created by github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere.(*Reconciler).Start
	/opt/app-root/src/github.com/konveyor/virt-controller/pkg/controller/provider/container/vsphere/reconciler.go:309 +0xc2

```
