### PR TITLE
Add integration with MA.

### DIFF
--- a/pkg/controller/provider/container/ocp/collection.go
+++ b/pkg/controller/provider/container/ocp/collection.go
@@ -53,7 +53,7 @@ func (r *StorageClass) Reconcile(ctx context.Context) (err error) {
 		m.With(&resource)
 		r.Reconciler.UpdateThreshold(m)
 		Log.Info("Create", libref.ToKind(m), m.String())
-		err = db.Insert(m)
+		err = tx.Insert(m)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -156,7 +156,7 @@ func (r *NetworkAttachmentDefinition) Reconcile(ctx context.Context) (err error)
 		m.With(&resource)
 		r.Reconciler.UpdateThreshold(m)
 		Log.Info("Create", libref.ToKind(m), m.String())
-		err = db.Insert(m)
+		err = tx.Insert(m)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -259,7 +259,7 @@ func (r *Namespace) Reconcile(ctx context.Context) (err error) {
 		m.With(&resource)
 		r.Reconciler.UpdateThreshold(m)
 		Log.Info("Create", libref.ToKind(m), m.String())
-		err = db.Insert(m)
+		err = tx.Insert(m)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return

--- a/pkg/controller/provider/container/vsphere/watch.go
+++ b/pkg/controller/provider/container/vsphere/watch.go
@@ -1,0 +1,180 @@
+package vsphere
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/vsphere"
+	xavier "github.com/konveyor/virt-controller/pkg/controller/provider/xavier/base"
+	xadapter "github.com/konveyor/virt-controller/pkg/controller/provider/xavier/vsphere"
+)
+
+//
+// VM Watch.
+// Watch for VM changes and analyze as needed.
+type WatchVM struct {
+	libmodel.DB
+}
+
+//
+// VM Created.
+// Analyzed as needed.
+func (r WatchVM) Created(event libmodel.Event) {
+	vm, cast := event.Model.(*model.VM)
+	if !cast {
+		return
+	}
+	if vm.Analyzed() {
+		return
+	}
+
+	r.analyze(vm)
+}
+
+//
+// VM Updated.
+// Analyzed as needed.
+func (r WatchVM) Updated(event libmodel.Event) {
+	vm, cast := event.Updated.(*model.VM)
+	if !cast {
+		return
+	}
+	if vm.Analyzed() {
+		return
+	}
+
+	r.analyze(vm)
+}
+
+// VM Deleted.
+func (r WatchVM) Deleted(event libmodel.Event) {
+}
+
+//
+// Report errors.
+func (r WatchVM) Error(err error) {
+	Log.Trace(liberr.Wrap(err))
+}
+
+//
+// Watch ended.
+func (r WatchVM) End() {
+}
+
+//
+// Analyze the VM.
+func (r WatchVM) analyze(vm *model.VM) {
+	tx, err := r.DB.Begin()
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+	defer tx.End()
+	err = tx.Get(vm)
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+	client := xavier.New(r.DB, &xadapter.Adapter{DB: r.DB})
+	err = client.Analyze(vm)
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+	err = tx.Update(vm)
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+	err = tx.Commit()
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+}
+
+//
+// Cluster Watch.
+// Watch for cluster changes and analyze as needed.
+type WatchCluster struct {
+	libmodel.DB
+}
+
+//
+// Cluster created.
+// Analyze all related VMs.
+func (r WatchCluster) Created(event libmodel.Event) {
+	cluster, cast := event.Model.(*model.Cluster)
+	if cast {
+		r.analyze(cluster)
+	}
+}
+
+//
+// Cluster updated.
+// Analyze all related VMs.
+func (r WatchCluster) Updated(event libmodel.Event) {
+	cluster, cast := event.Model.(*model.Cluster)
+	if cast {
+		r.analyze(cluster)
+	}
+}
+
+//
+// Cluster deleted.
+func (r WatchCluster) Deleted(event libmodel.Event) {
+}
+
+//
+// Report errors.
+func (r WatchCluster) Error(err error) {
+	Log.Trace(liberr.Wrap(err))
+}
+
+//
+// Watch ended.
+func (r WatchCluster) End() {
+}
+
+//
+// Analyze all of the VMs related to the cluster.
+func (r WatchCluster) analyze(cluster *model.Cluster) {
+	tx, err := r.DB.Begin()
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+	defer tx.End()
+	hostList := model.RefList{}
+	hostList.With(cluster.Hosts)
+	for _, ref := range hostList {
+		host := &model.Host{}
+		host.WithRef(ref)
+		err = tx.Get(host)
+		if err != nil {
+			Log.Trace(liberr.Wrap(err))
+			return
+		}
+		vmList := model.RefList{}
+		vmList.With(host.Vms)
+		for _, ref := range vmList {
+			vm := &model.VM{}
+			vm.WithRef(ref)
+			err = tx.Get(vm)
+			if err != nil {
+				Log.Trace(liberr.Wrap(err))
+				return
+			}
+			vm.RevisionAnalyzed = 0
+			err = tx.Update(vm)
+			if err != nil {
+				Log.Trace(liberr.Wrap(err))
+				return
+			}
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		Log.Trace(liberr.Wrap(err))
+		return
+	}
+}

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/konveyor/virt-controller/pkg/controller/provider/model"
 	ocpmodel "github.com/konveyor/virt-controller/pkg/controller/provider/model/ocp"
 	"github.com/konveyor/virt-controller/pkg/controller/provider/web"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/xavier"
 	"github.com/konveyor/virt-controller/pkg/settings"
 	core "k8s.io/api/core/v1"
 	clienterror "k8s.io/apimachinery/pkg/api/errors"
@@ -69,6 +70,7 @@ func init() {
 	container.Log = &log
 	web.Log = &log
 	model.Log = &log
+	xavier.Log = &log
 }
 
 //
@@ -257,14 +259,16 @@ func (r *Reconciler) updateContainer(provider *api.Provider) error {
 
 //
 // Build DB for provider.
-func (r *Reconciler) getDB(provider *api.Provider) libmodel.DB {
+func (r *Reconciler) getDB(provider *api.Provider) (db libmodel.DB) {
 	dir := Settings.Inventory.WorkingDir
 	dir = filepath.Join(dir, provider.Namespace)
 	os.MkdirAll(dir, 0755)
 	file := provider.Name + ".db"
 	path := filepath.Join(dir, file)
 	models := model.Models(provider)
-	return libmodel.New(path, models...)
+	db = libmodel.New(path, models...)
+	db.Journal().Enable()
+	return
 }
 
 //

--- a/pkg/controller/provider/web/vsphere/resource.go
+++ b/pkg/controller/provider/web/vsphere/resource.go
@@ -11,6 +11,8 @@ type Resource struct {
 	ID string `json:"id"`
 	// Parent.
 	Parent *model.Ref `json:"parent"`
+	// Revision
+	Revision int64 `json:"revision"`
 	// Object name.
 	Name string `json:"name"`
 	// Self link.
@@ -22,5 +24,6 @@ type Resource struct {
 func (r *Resource) With(m *model.Base) {
 	r.ID = m.ID
 	r.Parent = (&model.Ref{}).With(m.Parent)
+	r.Revision = m.Revision
 	r.Name = m.Name
 }

--- a/pkg/controller/provider/web/vsphere/vm.go
+++ b/pkg/controller/provider/web/vsphere/vm.go
@@ -112,28 +112,29 @@ func (h VMHandler) Link(p *api.Provider, m *model.VM) string {
 // REST Resource.
 type VM struct {
 	Resource
-	UUID                  string          `json:"uuid"`
-	Firmware              string          `json:"firmware"`
-	CpuAffinity           model.List      `json:"cpuAffinity"`
-	CpuHotAddEnabled      bool            `json:"cpuHostAddEnabled"`
-	CpuHotRemoveEnabled   bool            `json:"cpuHostRemoveEnabled"`
-	MemoryHotAddEnabled   bool            `json:"memoryHotAddEnabled"`
-	FaultToleranceEnabled bool            `json:"faultToleranceEnabled"`
-	CpuCount              int32           `json:"cpuCount"`
-	CoresPerSocket        int32           `json:"coresPerSocket"`
-	MemoryMB              int32           `json:"memoryMB"`
-	GuestName             string          `json:"guestName"`
-	BalloonedMemory       int32           `json:"balloonedMemory"`
-	IpAddress             string          `json:"ipAddress"`
-	StorageUsed           int64           `json:"storageUsed"`
-	NumaNodeAffinity      model.List      `json:"numaNodeAffinity"`
-	SriovSupported        bool            `json:"sriovSupported"`
-	PassthroughSupported  bool            `json:"passthroughSupported"`
-	UsbSupported          bool            `json:"usbSupported"`
-	Networks              model.RefList   `json:"networks"`
-	Disks                 []model.Disk    `json:"disks"`
-	Host                  model.Ref       `json:"host"`
-	Concerns              []model.Concern `json:"concerns"`
+	UUID                  string        `json:"uuid"`
+	Firmware              string        `json:"firmware"`
+	CpuAffinity           model.List    `json:"cpuAffinity"`
+	CpuHotAddEnabled      bool          `json:"cpuHostAddEnabled"`
+	CpuHotRemoveEnabled   bool          `json:"cpuHostRemoveEnabled"`
+	MemoryHotAddEnabled   bool          `json:"memoryHotAddEnabled"`
+	FaultToleranceEnabled bool          `json:"faultToleranceEnabled"`
+	CpuCount              int32         `json:"cpuCount"`
+	CoresPerSocket        int32         `json:"coresPerSocket"`
+	MemoryMB              int32         `json:"memoryMB"`
+	GuestName             string        `json:"guestName"`
+	BalloonedMemory       int32         `json:"balloonedMemory"`
+	IpAddress             string        `json:"ipAddress"`
+	StorageUsed           int64         `json:"storageUsed"`
+	NumaNodeAffinity      model.List    `json:"numaNodeAffinity"`
+	SriovSupported        bool          `json:"sriovSupported"`
+	PassthroughSupported  bool          `json:"passthroughSupported"`
+	UsbSupported          bool          `json:"usbSupported"`
+	Networks              model.RefList `json:"networks"`
+	Disks                 []model.Disk  `json:"disks"`
+	Host                  model.Ref     `json:"host"`
+	RevisionAnalyzed      int64         `json:"revisionAnalyzed"`
+	Concerns              model.List    `json:"concerns"`
 }
 
 //
@@ -161,14 +162,8 @@ func (r *VM) With(m *model.VM) {
 	r.Networks = *model.RefListPtr().With(m.Networks)
 	r.Disks = m.DecodeDisks()
 	r.Host = *(&model.Ref{}).With(m.Host)
-	r.Concerns = m.DecodeConcerns()
-	// TODO: EXAMPLE FOR UI DEV --REMOVE THIS.
-	r.Concerns = append(
-		r.Concerns,
-		model.Concern{
-			Name:     "Example",
-			Severity: "Warning",
-		})
+	r.RevisionAnalyzed = m.RevisionAnalyzed
+	r.Concerns = *(&model.List{}).With(m.Concerns)
 }
 
 //

--- a/pkg/controller/provider/xavier/base/client.go
+++ b/pkg/controller/provider/xavier/base/client.go
@@ -1,0 +1,343 @@
+package base
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	liberr "github.com/konveyor/controller/pkg/error"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/model/vsphere"
+	"github.com/konveyor/virt-controller/pkg/settings"
+	"io/ioutil"
+	"net/http"
+	liburl "net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+//
+// Body object fields.
+const (
+	Provider        = "provider"
+	DataCenter      = "datacenter"
+	Cluster         = "cluster"
+	VmName          = "vmName"
+	DiskSpace       = "diskSpace"
+	Memory          = "memory"
+	CpuCores        = "cpuCores"
+	GuestOs         = "guestOSFullName"
+	OsProduct       = "osProductName"
+	Product         = "product"
+	Version         = "version"
+	HostName        = "host_name"
+	BalloonedMemory = "balloonedMemory"
+	HasMemoryHotAdd = "hasMemoryHotAdd"
+	HasCpuHotAdd    = "hasCpuHotAdd"
+	HasCpuHotRemove = "hasCpuHotRemove"
+	HasCpuAffinity  = "cpuAffinityNotNull"
+	HasDrsEnabled   = "hasVmDrsConfig"
+	HasHaEnabled    = "hasVmHaConfig"
+	HasPassthrough  = "hasPassthroughDevice"
+	HasUsb          = "hasUSBcontrollers"
+	HasRdmDisk      = "hasRdmDisk"
+	ScanDate        = "scanRunDate"
+)
+
+//
+// Application settings.
+var Settings = &settings.Settings
+
+type List = []interface{}
+
+type Object = map[string]interface{}
+
+//
+// Model adapter.
+type ModelAdapter interface {
+	// Update concerns.
+	UpdateConcerns(model libmodel.Model, concerns []string)
+	// Update the xavier body.
+	UpdateBody(object Object, model libmodel.Model) error
+}
+
+//
+// Factory.
+func New(db libmodel.DB, adapter ModelAdapter) *Client {
+	return &Client{
+		DB:       db,
+		URL:      Settings.Inventory.Xavier.URL,
+		User:     Settings.Inventory.Xavier.User,
+		Password: Settings.Inventory.Xavier.Password,
+		Adapter:  adapter,
+	}
+}
+
+//
+// Xavier client.
+type Client struct {
+	// Database.
+	libmodel.DB
+	// Service URL.
+	URL string
+	// User.
+	User string
+	// Password
+	Password string
+	// Builder
+	Adapter ModelAdapter
+}
+
+//
+// Analyze the specified VM.
+func (r *Client) Analyze(model libmodel.Model) (err error) {
+	concerns := []string{}
+	if r.URL == "" {
+		r.Adapter.UpdateConcerns(model, concerns)
+		Log.Info("Xavier: URL not configured.")
+		return
+	}
+	if mX, cast := model.(interface{ Analyzed() bool }); cast {
+		if mX.Analyzed() {
+			return
+		}
+	}
+	reply := Object{}
+	body, err := r.body(model)
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+	err = r.post(&body, &reply)
+	if err != nil {
+		return
+	}
+	report, err := r.find(
+		reply,
+		"result",
+		"execution-results",
+		"results",
+		"2",
+		"value",
+		"org.drools.core.runtime.rule.impl.FlatQueryResults",
+		"idResultMaps",
+		"element",
+		"0",
+		"element",
+		"0",
+		"value",
+		"org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel")
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	providers, err := r.find(report, "recommendedTargetsIMS")
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	flags, err := r.find(report, "flagsIMS")
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if list, cast := flags.(List); cast {
+		for _, flag := range list {
+			concerns = append(concerns, flag.(string))
+		}
+	}
+	if len(concerns) == 0 {
+		recommended := false
+		if list, cast := providers.(List); cast {
+			for _, provider := range list {
+				if provider == "OCP" {
+					recommended = true
+					break
+				}
+			}
+		}
+		if !recommended {
+			concerns = append(
+				concerns,
+				"CNV not recommended.")
+		}
+	}
+	r.Adapter.UpdateConcerns(model, concerns)
+
+	Log.Info("Analyzed", "vm", model.String())
+
+	return
+}
+
+//
+// Build body
+func (r *Client) body(model libmodel.Model) (body Object, err error) {
+	about, _ := r.about()
+	object := Object{
+		Provider:        "",
+		DataCenter:      "",
+		Cluster:         "",
+		VmName:          "",
+		DiskSpace:       0,
+		Memory:          0,
+		CpuCores:        0,
+		GuestOs:         "",
+		OsProduct:       "",
+		Product:         about.Product,
+		Version:         about.APIVersion,
+		HostName:        "",
+		HasMemoryHotAdd: false,
+		HasCpuHotAdd:    false,
+		HasCpuHotRemove: false,
+		HasCpuAffinity:  false,
+		HasDrsEnabled:   false,
+		HasHaEnabled:    false,
+		HasPassthrough:  false,
+		HasUsb:          false,
+		HasRdmDisk:      false,
+		BalloonedMemory: 0,
+		ScanDate:        time.Now().Unix(),
+	}
+	insert := Object{
+		"object": Object{
+			"org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel": object,
+		},
+		"out-identifier": "input",
+	}
+	body = Object{
+		"lookup": "WorkloadInventoryKSession0",
+		"commands": List{
+			Object{
+				"insert": insert,
+			},
+			Object{
+				"fire-all-rules": Object{
+					"out-identifier": "firedActivations",
+				},
+			},
+			Object{
+				"query": Object{
+					"name":           "GetWorkloadInventoryReports",
+					"out-identifier": "WorkloadInventoryReports",
+					"arguments":      List{},
+				},
+			},
+		},
+	}
+	err = r.Adapter.UpdateBody(object, model)
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
+
+	return
+}
+
+//
+// Add headers.
+func (r Client) header() (header http.Header) {
+	header = http.Header{}
+	header.Add("Content-Type", "application/json")
+	encoded := base64.StdEncoding.EncodeToString(
+		[]byte(strings.Join([]string{
+			r.User,
+			r.Password,
+		}, ":")))
+	header.Add(
+		"Authorization",
+		"Basic "+encoded)
+
+	return
+}
+
+//
+// Post validation request.
+func (r *Client) post(in, out *Object) (err error) {
+	parsedURL, err := liburl.Parse(r.URL)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	body, _ := json.Marshal(in)
+	reader := bytes.NewReader(body)
+	request := &http.Request{
+		Method: http.MethodPost,
+		Body:   ioutil.NopCloser(reader),
+		URL:    parsedURL,
+		Header: r.header(),
+	}
+	client := http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	status := response.StatusCode
+	content := []byte{}
+	if status == http.StatusOK {
+		defer response.Body.Close()
+		content, err = ioutil.ReadAll(response.Body)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+		err = json.Unmarshal(content, out)
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
+	} else {
+		err = liberr.New(http.StatusText(status))
+	}
+
+	return
+}
+
+//
+// Get object at path.
+func (r Client) find(in interface{}, path ...string) (out interface{}, err error) {
+	object := in
+	for _, key := range path {
+		switch object.(type) {
+		case List:
+			index, nErr := strconv.Atoi(key)
+			if nErr != nil {
+				err = liberr.Wrap(nErr)
+				return
+			}
+			list := object.(List)
+			if index < len(list) {
+				object = list[index]
+			} else {
+				err = liberr.New("path not valid")
+				return
+			}
+		case Object:
+			found := false
+			object, found = object.(Object)[key]
+			if !found {
+				err = liberr.New("path not valid")
+				return
+			}
+		case string, int:
+			return
+		default:
+			err = liberr.New("path not valid")
+			return
+		}
+	}
+
+	out = object
+
+	return
+}
+
+//
+// About vSphere.
+func (r *Client) about() (about *vsphere.About, err error) {
+	about = &vsphere.About{}
+	err = r.DB.Get(about)
+	if err != nil {
+		liberr.Wrap(err)
+	}
+
+	return
+}

--- a/pkg/controller/provider/xavier/base/doc.go
+++ b/pkg/controller/provider/xavier/base/doc.go
@@ -1,0 +1,12 @@
+package base
+
+import "github.com/konveyor/controller/pkg/logging"
+
+//
+// Shared logger.
+var Log *logging.Logger
+
+func init() {
+	log := logging.WithName("xavier")
+	Log = &log
+}

--- a/pkg/controller/provider/xavier/doc.go
+++ b/pkg/controller/provider/xavier/doc.go
@@ -1,0 +1,16 @@
+package xavier
+
+import (
+	"github.com/konveyor/controller/pkg/logging"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/xavier/base"
+)
+
+//
+// Shared logger.
+var Log *logging.Logger
+
+func init() {
+	log := logging.WithName("xavier")
+	base.Log = &log
+	Log = &log
+}

--- a/pkg/controller/provider/xavier/vsphere/adapter.go
+++ b/pkg/controller/provider/xavier/vsphere/adapter.go
@@ -1,0 +1,78 @@
+package vsphere
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	libmodel "github.com/konveyor/controller/pkg/inventory/model"
+	model "github.com/konveyor/virt-controller/pkg/controller/provider/model/vsphere"
+	"github.com/konveyor/virt-controller/pkg/controller/provider/xavier/base"
+)
+
+//
+// Model adapter.
+type Adapter struct {
+	// DB
+	libmodel.DB
+}
+
+//
+// Update the vSphere xavier body.
+func (r *Adapter) UpdateBody(object base.Object, m libmodel.Model) (err error) {
+	vm := m.(*model.VM)
+	cluster, err := vm.Cluster(r.DB)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	object[base.VmName] = vm.Name
+	object[base.DiskSpace] = vm.StorageUsed
+	object[base.Memory] = vm.MemoryMB
+	object[base.CpuCores] = vm.CpuCount
+	object[base.GuestOs] = vm.GuestName
+	object[base.BalloonedMemory] = vm.BalloonedMemory
+	object[base.HasMemoryHotAdd] = vm.MemoryHotAddEnabled
+	object[base.HasCpuHotAdd] = vm.CpuHotAddEnabled
+	object[base.HasCpuHotRemove] = vm.CpuHotRemoveEnabled
+	object[base.HasCpuAffinity] = r.hasCpuAffinity(vm)
+	object[base.HasRdmDisk] = r.hasRdmDisk(vm)
+	object[base.HasPassthrough] = vm.PassthroughSupported
+	object[base.HasUsb] = vm.UsbSupported
+	object[base.HasDrsEnabled] = cluster.DrsEnabled
+	object[base.HasHaEnabled] = cluster.DasEnabled
+	return
+}
+
+//
+// Update VM concerns.
+func (r *Adapter) UpdateConcerns(m libmodel.Model, concerns []string) {
+	vm := m.(*model.VM)
+	list := model.List{}
+	for _, name := range concerns {
+		list = append(
+			list,
+			model.Concern{
+				Severity: model.Warning,
+				Name:     name,
+			})
+	}
+	vm.Concerns = list.Encode()
+	vm.RevisionAnalyzed = vm.Revision
+
+	return
+}
+
+func (r *Adapter) hasCpuAffinity(vm *model.VM) bool {
+	list := model.List{}
+	list.With(vm.CpuAffinity)
+	return len(list) > 0
+}
+
+func (r *Adapter) hasRdmDisk(vm *model.VM) (has bool) {
+	for _, disk := range vm.DecodeDisks() {
+		if disk.RDM {
+			has = true
+			return
+		}
+	}
+
+	return
+}

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -24,6 +24,9 @@ const (
 	TLSCertificate = "API_TLS_CERTIFICATE"
 	TLSKey         = "API_TLS_KEY"
 	TLSCa          = "API_TLS_CA"
+	XavierURL      = "XAVIER_URL"
+	XavierUser     = "XAVIER_USER"
+	XavierPassword = "XAVIER_PASSWORD"
 )
 
 //
@@ -56,6 +59,15 @@ type Inventory struct {
 		Key string
 		// CA path
 		CA string
+	}
+	// Xavier settings.
+	Xavier struct {
+		// URL.
+		URL string
+		// User name.
+		User string
+		// Password.
+		Password string
 	}
 }
 
@@ -108,6 +120,16 @@ func (r *Inventory) Load() error {
 		} else {
 			r.TLS.CA = ServiceCAFile
 		}
+	}
+	// Xavier.
+	if s, found := os.LookupEnv(XavierURL); found {
+		r.Xavier.URL = s
+	}
+	if s, found := os.LookupEnv(XavierUser); found {
+		r.Xavier.User = s
+	}
+	if s, found := os.LookupEnv(XavierPassword); found {
+		r.Xavier.Password = s
 	}
 
 	return nil


### PR DESCRIPTION
Initial integration with MA (xavier) validation service.
Adds:
- _Xavier_ client.
- A `revision` property to all resources.
- A `revisionAnalyzed` property which indicates the `revision` reflected in the analytics `concerns`.
- Triggered by _watch_ on vSphere Cluster and VM database entities.  Likely add a _watch_ on other kinds (Eg: Network) in the next iteration.

Need operator to set:
- XAVIER_URL
- XAVIER_USER
- XAVIER_PASSWORD

 in the virt-controller configMap.  Related PR (TBD).  Re: [issue/43](https://github.com/konveyor/virt-operator/issues/43).

Also, includes /vendor change for _common_ controller lib fix.

Requires: https://github.com/konveyor/controller/pull/34