### PR TITLE
Enable TLS for inventory

### DIFF
--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -89,6 +89,9 @@ func Add(mgr manager.Manager) error {
 	container := libcontainer.New()
 	web := libweb.New(container, web.All(container)...)
 	web.Port = Settings.Inventory.Port
+	web.TLS.Enabled = Settings.Inventory.TLS.Enabled
+	web.TLS.Certificate = Settings.Inventory.TLS.Certificate
+	web.TLS.Key = Settings.Inventory.TLS.Key
 	web.AllowedOrigins = Settings.CORS.AllowedOrigins
 	reconciler := &Reconciler{
 		Client:    nClient,

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -14,6 +14,7 @@ const (
 	AuthOptional   = "AUTH_OPTIONAL"
 	Host           = "API_HOST"
 	Port           = "API_PORT"
+	TLSSecretName  = "TLS_SECRET_NAME"
 )
 
 //
@@ -36,6 +37,15 @@ type Inventory struct {
 	Host string
 	// Port
 	Port int
+	// TLS
+	TLS struct {
+		// Enabled.
+		Enabled bool
+		// Certificate path
+		Certificate string
+		// Key path
+		Key string
+	}
 }
 
 //
@@ -72,6 +82,14 @@ func (r *Inventory) Load() error {
 		r.Port, _ = strconv.Atoi(s)
 	} else {
 		r.Port = 8080
+	}
+	// TLS
+	if s, found := os.LookupEnv(TLSSecretName); found {
+		r.TLS.Enabled = true
+		r.TLS.Certificate = "/var/run/secrets/" + s + "/tls.crt"
+		r.TLS.Key = "/var/run/secrets/" + s + "/tls.key"
+	} else {
+		r.TLS.Enabled = false
 	}
 
 	return nil


### PR DESCRIPTION
This pull request enabled TLS for the inventory container. If a secret name is passed as the `TLS_SECRET_NAME` environment variable, the TLS configuration is enabled and passed to the inventory container (see [konveyor/controller#29](https://github.com/konveyor/controller/pull/29)). The web client is also configured to use TLS and uses the openshift-signer CA certificate to validate the inventory service certificate.

Depends on https://github.com/konveyor/controller/pull/29.