### PR TITLE
Use internal mapping in VirtualMachineImport CR

### DIFF
--- a/pkg/controller/plan/builder/doc.go
+++ b/pkg/controller/plan/builder/doc.go
@@ -19,9 +19,9 @@ type Builder interface {
 	// Build secret.
 	Secret(vmID string, in, object *core.Secret) (err error)
 	// Build VMIO resource mapping.
-	Mapping(mp *plan.Map, object *vmio.ResourceMapping) error
+	Mapping(mp *plan.Map, object *vmio.VirtualMachineImportSpec) error
 	// Build VMIO import spec.
-	Import(vmID string, object *vmio.VirtualMachineImportSpec) error
+	Import(vmID string, mp *plan.Map, object *vmio.VirtualMachineImportSpec) error
 	// Build tasks.
 	Tasks(vmID string) ([]*plan.Task, error)
 }

--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -145,7 +145,7 @@ func (r *Builder) host(hostID string) (host *vsphere.Host, err error) {
 
 //
 // Build the VMIO ResourceMapping CR.
-func (r *Builder) Mapping(mp *plan.Map, object *vmio.ResourceMapping) (err error) {
+func (r *Builder) Mapping(mp *plan.Map, object *vmio.VirtualMachineImportSpec) (err error) {
 	netMap := []vmio.NetworkResourceMappingItem{}
 	dsMap := []vmio.StorageResourceMappingItem{}
 	for i := range mp.Networks {
@@ -175,7 +175,7 @@ func (r *Builder) Mapping(mp *plan.Map, object *vmio.ResourceMapping) (err error
 				},
 			})
 	}
-	object.Spec.VmwareMappings = &vmio.VmwareMappings{
+	object.Source.Vmware.Mappings = &vmio.VmwareMappings{
 		NetworkMappings: &netMap,
 		StorageMappings: &dsMap,
 	}
@@ -185,7 +185,7 @@ func (r *Builder) Mapping(mp *plan.Map, object *vmio.ResourceMapping) (err error
 
 //
 // Build the VMIO VM Import Spec.
-func (r *Builder) Import(vmID string, object *vmio.VirtualMachineImportSpec) (err error) {
+func (r *Builder) Import(vmID string, mp *plan.Map, object *vmio.VirtualMachineImportSpec) (err error) {
 	vm := &vsphere.VM{}
 	status, pErr := r.Inventory.Get(vm, vmID)
 	if pErr != nil {
@@ -201,6 +201,7 @@ func (r *Builder) Import(vmID string, object *vmio.VirtualMachineImportSpec) (er
 				ID: &uuid,
 			},
 		}
+		r.Mapping(mp, object)
 	default:
 		err = liberr.New(
 			fmt.Sprintf(

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -156,23 +156,6 @@ func (r *KubeVirt) EnsureNamespace() (err error) {
 }
 
 //
-// Ensure the VMIO mapping exists on the destination.
-func (r *KubeVirt) EnsureMapping() (err error) {
-	mapping, err := r.buildMapping()
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-	err = r.ensureObject(mapping)
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-
-	return
-}
-
-//
 // Ensure the VMIO secret exists on the destination.
 func (r *KubeVirt) EnsureSecret(vmID string) (err error) {
 	secret, err := r.buildSecret(vmID)
@@ -193,6 +176,13 @@ func (r *KubeVirt) EnsureSecret(vmID string) (err error) {
 // Build the VMIO CR.
 func (r *KubeVirt) buildImport(vm *plan.VMStatus) (object *vmio.VirtualMachineImport, err error) {
 	namespace := r.namespace()
+	sn := snapshot.New(r.Migration)
+	mp := &plan.Map{}
+	err = sn.Get(api.MapSnapshot, mp)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
 	object = &vmio.VirtualMachineImport{
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: r.namespace(),
@@ -208,46 +198,14 @@ func (r *KubeVirt) buildImport(vm *plan.VMStatus) (object *vmio.VirtualMachineIm
 				Namespace: &namespace,
 				Name:      r.nameForSecret(vm.ID),
 			},
-			ResourceMapping: &vmio.ObjectIdentifier{
-				Namespace: &namespace,
-				Name:      r.nameForMapping(),
-			},
 		},
 	}
-	err = r.Builder.Import(vm.ID, &object.Spec)
+	err = r.Builder.Import(vm.ID, mp, &object.Spec)
 	if err != nil {
 		err = liberr.Wrap(err)
 	}
 	if vm.Name != "" {
 		object.Spec.TargetVMName = &vm.Name
-	}
-
-	return
-}
-
-//
-// Build the ResourceMapping CR.
-func (r *KubeVirt) buildMapping() (object *vmio.ResourceMapping, err error) {
-	object = &vmio.ResourceMapping{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: r.namespace(),
-			Name:      r.nameForMapping(),
-			Labels: map[string]string{
-				kMigration: string(r.Plan.Status.Migration.Active),
-				kPlan:      string(r.Plan.UID),
-			},
-		},
-	}
-	sn := snapshot.New(r.Migration)
-	mp := &plan.Map{}
-	err = sn.Get(api.MapSnapshot, mp)
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-	err = r.Builder.Mapping(mp, object)
-	if err != nil {
-		err = liberr.Wrap(err)
 	}
 
 	return

--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -233,19 +233,6 @@ func (r *KubeVirt) buildSecret(vmID string) (object *core.Secret, err error) {
 }
 
 //
-// Generated name for kubevirt VM Import mapping CR.
-func (r *KubeVirt) nameForMapping() string {
-	uid := string(r.Plan.UID)
-	parts := []string{
-		"plan",
-		r.Plan.Name,
-		uid[len(uid)-4:],
-	}
-
-	return strings.Join(parts, "-")
-}
-
-//
 // Generated name for kubevirt VM Import CR secret.
 func (r *KubeVirt) nameForSecret(vmID string) string {
 	uid := string(r.Plan.UID)

--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -324,11 +324,6 @@ func (r *Migration) begin() (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	err = r.kubevirt.EnsureMapping()
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
 	//
 	// Delete
 	for _, status := range r.Plan.Status.Migration.VMs {


### PR DESCRIPTION
This pull request changes the VirtualMachineImport build to:

- Snapshot the plan map in `plan.kubevirt.buildImport` and passing it to `plan.builder.vsphere.builder.Import`.
- Modify `plan.builder.vsphere.builder.Mapping` to embed the `VMImport.Spec.Source.Vmware.Mappings`.
- Modify `plan.builder.vsphere.builder.Mapping` to write the mappings in `VMImport.Spec.Source.Vmware.Mappings`.

Closes #84 