### PR TITLE
Fix inventory client when TLS is enabled

### DIFF
--- a/pkg/controller/provider/web/base/client.go
+++ b/pkg/controller/provider/web/base/client.go
@@ -160,7 +160,11 @@ func (c *Client) url(path string) *liburl.URL {
 	path = (&Handler{}).Link(path, c.Params)
 	url, _ := liburl.Parse(path)
 	if url.Host == "" {
-		url.Scheme = "http"
+		if Settings.Inventory.TLS.Enabled {
+			url.Scheme = "https"
+		} else {
+			url.Scheme = "http"
+		}
 		url.Host = c.Host
 	}
 

--- a/pkg/settings/inventory.go
+++ b/pkg/settings/inventory.go
@@ -14,6 +14,7 @@ const (
 	AuthOptional   = "AUTH_OPTIONAL"
 	Host           = "API_HOST"
 	Port           = "API_PORT"
+	TLSEnabled     = "API_TLS_ENABLED"
 	TLSCertificate = "API_TLS_CERTIFICATE"
 	TLSKey         = "API_TLS_KEY"
 )
@@ -85,14 +86,16 @@ func (r *Inventory) Load() error {
 		r.Port = 8080
 	}
 	// TLS
-	if cert, found := os.LookupEnv(TLSCertificate); found {
-		if key, found := os.LookupEnv(TLSKey); found {
-			r.TLS.Certificate = cert
-			r.TLS.Key = key
-			r.TLS.Enabled = true
+	r.TLS.Enabled = false
+	if s, found := os.LookupEnv(TLSEnabled); found {
+		if r.TLS.Enabled, _ = strconv.ParseBool(s); r.TLS.Enabled {
+			if cert, found := os.LookupEnv(TLSCertificate); found {
+				if key, found := os.LookupEnv(TLSKey); found {
+					r.TLS.Certificate = cert
+					r.TLS.Key = key
+				}
+			}
 		}
-	} else {
-		r.TLS.Enabled = false
 	}
 
 	return nil


### PR DESCRIPTION
With #79 merged, the inventory client doesn't find the right environment variables on the `main` container, so it is still trying to connect to http://localhost:8080. This pull request adds a `API_TLS_ENABLED` environment variable that affects the scheme.

The `API_HOST` and `API_PORT` environment variables can also be used to affect the rest of the base URL. This is done in [konveyor/virt-operator#44](https://github.com/konveyor/virt-operator/pull/44) to ensure the hostname matches the certificate subject.