### PR TITLE
Add type to VMIO network mapping

### DIFF
--- a/pkg/controller/plan/builder/vsphere/builder.go
+++ b/pkg/controller/plan/builder/vsphere/builder.go
@@ -160,6 +160,7 @@ func (r *Builder) Mapping(mp *plan.Map, object *vmio.ResourceMapping) (err error
 					Namespace: &network.Destination.Namespace,
 					Name:      network.Destination.Name,
 				},
+				Type: &network.Destination.Type,
 			})
 	}
 	for i := range mp.Datastores {


### PR DESCRIPTION
ResourceMapping sections of VirtualMachineImport CRs doesn't have the NetworkMapping.Type (pod/multus).
When only one network is mapped, this works because VMIO default is pod. However, it fails when there's more than one network as they all default to `pod` and a VM can only be connected once to the pod network.

This pull request propagates the type to the VMIO ResourceMapping.