### PR TITLE
Add Prometheus metrics reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/gin-gonic/gin v1.7.2
+	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-logr/logr v0.3.0
 	github.com/go-openapi/spec v0.19.4 // indirect
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
@@ -11,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.10.3
 	github.com/ovirt/go-ovirt v4.3.4+incompatible
 	github.com/pkg/profile v1.3.0
-	github.com/prometheus/client_golang v1.8.0 // indirect
+	github.com/prometheus/client_golang v1.11.0
 	github.com/vmware/govmomi v0.23.1
 	go.uber.org/zap v1.14.1 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0 h1:dXFJfIHVvUcpSgDOV+Ne6t7jXri8Tfv2uOLHUZ2XNuo=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
+github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
@@ -379,8 +380,10 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -480,8 +483,9 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
+github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jsonnet-bundler/jsonnet-bundler v0.1.0/go.mod h1:YKsSFc9VFhhLITkJS3X2PrRqWG9u2Jq99udTdDjQLfM=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -689,8 +693,8 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.8.0 h1:zvJNkoCFAnYFNC24FV8nW4JdRJ3GIFcLbg65lL/JDcw=
-github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
+github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
+github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -708,8 +712,8 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
-github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
-github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.26.0 h1:iMAkS2TDoNWnKM+Kopnx/8tnEStIfpYA0ur0xQzzhMQ=
+github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -722,8 +726,8 @@ github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
-github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
+github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.8.0/go.mod h1:fSI0j+IUQrDd7+ZtR9WKIGtoYAYAJUKcKhYLG25tN4g=
@@ -972,6 +976,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1035,8 +1040,9 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
+golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1208,8 +1214,9 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
-google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.26.0-rc.1 h1:7QnIQpGRHE5RnLKnESfDoxm2dTapTZua5a0kS0A+VXQ=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUyUwEgHQXw849cJrilpS5NeIjOWESAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -18,6 +18,7 @@ package migration
 
 import (
 	"context"
+
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	"github.com/konveyor/controller/pkg/logging"
 	libref "github.com/konveyor/controller/pkg/ref"
@@ -88,6 +89,9 @@ func Add(mgr manager.Manager) error {
 		log.Trace(err)
 		return err
 	}
+
+	// Gather migration metrics every 10 seconds
+	recordMetrics(mgr.GetClient())
 
 	return nil
 }

--- a/pkg/controller/migration/controller.go
+++ b/pkg/controller/migration/controller.go
@@ -90,7 +90,7 @@ func Add(mgr manager.Manager) error {
 		return err
 	}
 
-	// Gather migration metrics every 10 seconds
+	// Gather migration metrics
 	recordMetrics(mgr.GetClient())
 
 	return nil

--- a/pkg/controller/migration/metrics.go
+++ b/pkg/controller/migration/metrics.go
@@ -1,0 +1,72 @@
+package migration
+
+import (
+	"context"
+	"time"
+
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// 'status' - [ executing, succeeded, failed, canceled ]
+	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "mtv_workload_migrations",
+		Help: "VM Migrations sorted by status",
+	},
+		[]string{"status"},
+	)
+)
+
+func recordMetrics(client client.Client) {
+	go func() {
+		for {
+			time.Sleep(10 * time.Second)
+
+			// get all migration objects
+			migrations := api.MigrationList{}
+			err := client.List(context.TODO(), &migrations)
+
+			// if error occurs, retry 10 seconds later
+			if err != nil {
+				log.Info("Metrics Migrations list error: %v", err)
+				continue
+			}
+
+			// Holding counter vars used to make gauge update "atomic"
+			var executing, succeeded, failed, canceled float64
+
+			// for all migrations, count # in executing, succeeded, failed, canceled
+			for _, m := range migrations.Items {
+				if m.Status.HasCondition(Executing) {
+					executing++
+					continue
+				}
+				if m.Status.HasCondition(Succeeded) {
+					succeeded++
+					continue
+				}
+				if m.Status.HasCondition(Failed) {
+					failed++
+					continue
+				}
+				if m.Status.HasCondition(Canceled) {
+					canceled++
+					continue
+				}
+				// Migration object is created when the Plan has started, so there should not be any "Idle" migrations
+			}
+
+			migrationGauge.With(
+				prometheus.Labels{"status": Executing}).Set(executing)
+			migrationGauge.With(
+				prometheus.Labels{"status": Succeeded}).Set(succeeded)
+			migrationGauge.With(
+				prometheus.Labels{"status": Failed}).Set(failed)
+			migrationGauge.With(
+				prometheus.Labels{"status": Canceled}).Set(canceled)
+		}
+	}()
+}

--- a/pkg/controller/migration/metrics.go
+++ b/pkg/controller/migration/metrics.go
@@ -20,6 +20,8 @@ var (
 	)
 )
 
+//
+// Calculate Migrations metrics every 10 seconds
 func recordMetrics(client client.Client) {
 	go func() {
 		for {
@@ -56,7 +58,6 @@ func recordMetrics(client client.Client) {
 					canceled++
 					continue
 				}
-				// Migration object is created when the Plan has started, so there should not be any "Idle" migrations
 			}
 
 			migrationGauge.With(

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -159,7 +159,7 @@ func Add(mgr manager.Manager) error {
 		return err
 	}
 
-	// Gather migration Plan metrics every 10 seconds
+	// Gather migration Plan metrics
 	recordMetrics(mgr.GetClient())
 
 	return nil

--- a/pkg/controller/plan/controller.go
+++ b/pkg/controller/plan/controller.go
@@ -18,6 +18,10 @@ package plan
 
 import (
 	"context"
+	"path"
+	"sort"
+	"time"
+
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/controller/pkg/logging"
@@ -29,7 +33,6 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/settings"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/storage/names"
-	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -37,8 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"sort"
-	"time"
 )
 
 const (
@@ -157,6 +158,9 @@ func Add(mgr manager.Manager) error {
 		log.Trace(err)
 		return err
 	}
+
+	// Gather migration Plan metrics every 10 seconds
+	recordMetrics(mgr.GetClient())
 
 	return nil
 }

--- a/pkg/controller/plan/metrics.go
+++ b/pkg/controller/plan/metrics.go
@@ -1,0 +1,105 @@
+package plan
+
+import (
+	"context"
+	"time"
+
+	api "github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// 'status' - [ idle, executing, succeeded, failed, canceled, deleted, paused, pending, running, blocked ]
+	migrationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "mtv_workload_plans",
+		Help: "VM migration Plans sorted by status",
+	},
+		[]string{"status"},
+	)
+)
+
+func recordMetrics(client client.Client) {
+	go func() {
+		for {
+			time.Sleep(10 * time.Second)
+
+			// get all migration objects
+			plans := api.PlanList{}
+			err := client.List(context.TODO(), &plans)
+
+			// if error occurs, retry 10 seconds later
+			if err != nil {
+				log.Info("Metrics Plans list error: %v", err)
+				continue
+			}
+
+			// Holding counter vars used to make gauge update "atomic"
+			var idle, executing, succeeded, failed, canceled, deleted, paused, pending, running, blocked float64
+
+			// for all plans, count # in Idle, Executing, Succeeded, Failed, Canceled, Deleted, Paused, Pending, Running, Blocked
+			for _, m := range plans.Items {
+				if m.Status.HasCondition(Executing) {
+					executing++
+					continue
+				}
+				if m.Status.HasCondition(Succeeded) {
+					succeeded++
+					continue
+				}
+				if m.Status.HasCondition(Failed) {
+					failed++
+					continue
+				}
+				if m.Status.HasCondition(Canceled) {
+					canceled++
+					continue
+				}
+				if m.Status.HasCondition(Deleted) {
+					deleted++
+					continue
+				}
+				if m.Status.HasCondition(Paused) {
+					paused++
+					continue
+				}
+				if m.Status.HasCondition(Pending) {
+					pending++
+					continue
+				}
+				if m.Status.HasCondition(Running) {
+					running++
+					continue
+				}
+				if m.Status.HasCondition(Blocked) {
+					blocked++
+					continue
+				}
+				// If the Plan has no matching condition, but exists, it should be counted as Idle
+				idle++
+			}
+
+			migrationGauge.With(
+				prometheus.Labels{"status": "Idle"}).Set(idle)
+			migrationGauge.With(
+				prometheus.Labels{"status": Executing}).Set(executing)
+			migrationGauge.With(
+				prometheus.Labels{"status": Succeeded}).Set(succeeded)
+			migrationGauge.With(
+				prometheus.Labels{"status": Failed}).Set(failed)
+			migrationGauge.With(
+				prometheus.Labels{"status": Canceled}).Set(canceled)
+			migrationGauge.With(
+				prometheus.Labels{"status": Deleted}).Set(deleted)
+			migrationGauge.With(
+				prometheus.Labels{"status": Paused}).Set(paused)
+			migrationGauge.With(
+				prometheus.Labels{"status": Pending}).Set(pending)
+			migrationGauge.With(
+				prometheus.Labels{"status": Running}).Set(running)
+			migrationGauge.With(
+				prometheus.Labels{"status": Blocked}).Set(blocked)
+		}
+	}()
+}

--- a/pkg/controller/plan/metrics.go
+++ b/pkg/controller/plan/metrics.go
@@ -20,6 +20,8 @@ var (
 	)
 )
 
+//
+// Calculate Plans metrics every 10 seconds
 func recordMetrics(client client.Client) {
 	go func() {
 		for {


### PR DESCRIPTION
Adding Prometheus metrics reporting for migration and plans. More precisely it add a metrics endpoint exposing relevant aggregated usage metrics (migrations&plans by their statuses) and allow OpenShift telemetry to capture these metrics.

Inspired by solution in MTC/Crane project https://github.com/konveyor/mig-controller/pull/379

How to test quickly: Open terminal of the forklift-controller and run following command
```
curl http://localhost:2112/metrics | grep mtv
```
Example output (I have 3 plans - 1 cancelled (for 1 VM), 2 just created/not started)
```
...
# HELP mtv_workload_migrations VM Migrations sorted by status
# TYPE mtv_workload_migrations gauge
mtv_workload_migrations{status="Canceled"} 1
mtv_workload_migrations{status="Executing"} 0
mtv_workload_migrations{status="Failed"} 0
mtv_workload_migrations{status="Succeeded"} 0
# HELP mtv_workload_plans VM migration Plans sorted by status
# TYPE mtv_workload_plans gauge
mtv_workload_plans{status="Blocked"} 0
mtv_workload_plans{status="Canceled"} 1
mtv_workload_plans{status="Deleted"} 0
mtv_workload_plans{status="Executing"} 0
mtv_workload_plans{status="Failed"} 0
mtv_workload_plans{status="Idle"} 2
mtv_workload_plans{status="Paused"} 0
mtv_workload_plans{status="Pending"} 0
mtv_workload_plans{status="Running"} 0
mtv_workload_plans{status="Succeeded"} 0
...
```