### PR TITLE
Bug 2015940: Use DV names from VM spec for importer pod deletion

### DIFF
--- a/pkg/controller/plan/migration.go
+++ b/pkg/controller/plan/migration.go
@@ -402,11 +402,9 @@ func (r *Migration) deleteImporterPods(vm *plan.VMStatus) (err error) {
 	var vmCr VirtualMachine
 	found := false
 	if vmCr, found = r.vmMap[vm.ID]; found {
-		for _, dv := range vmCr.DataVolumes {
-			err = r.kubevirt.DeleteImporterPod(dv)
-			if err != nil {
-				return
-			}
+		err = r.kubevirt.DeleteImporterPods(&vmCr)
+		if err != nil {
+			return
 		}
 	}
 	return


### PR DESCRIPTION
Use the DV names from the VM spec to delete importer pods for successful VM migrations rather than the DVs from the VirtualMachineMap, because ListVMs() can't find DVs for a VM if there is not an active migration.