### PR TITLE
Bug 2017370: Add oVirt Warm Migration feature gate and associated Plan validation

### DIFF
--- a/pkg/controller/plan/adapter/base/doc.go
+++ b/pkg/controller/plan/adapter/base/doc.go
@@ -74,4 +74,6 @@ type Validator interface {
 	NetworksMapped(vmRef ref.Ref) (bool, error)
 	// Validate that a VM's Host isn't in maintenance mode.
 	MaintenanceMode(vmRef ref.Ref) (bool, error)
+	// Validate whether warm migration is supported from this provider type.
+	WarmMigration() bool
 }

--- a/pkg/controller/plan/adapter/ovirt/validator.go
+++ b/pkg/controller/plan/adapter/ovirt/validator.go
@@ -6,6 +6,7 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/apis/forklift/v1beta1/ref"
 	"github.com/konveyor/forklift-controller/pkg/controller/provider/web"
 	model "github.com/konveyor/forklift-controller/pkg/controller/provider/web/ovirt"
+	"github.com/konveyor/forklift-controller/pkg/settings"
 )
 
 //
@@ -19,6 +20,13 @@ type Validator struct {
 // Load.
 func (r *Validator) Load() (err error) {
 	r.inventory, err = web.NewClient(r.plan.Referenced.Provider.Source)
+	return
+}
+
+//
+// Validate whether warm migration is supported from this provider type.
+func (r *Validator) WarmMigration() (ok bool) {
+	ok = settings.Settings.Features.OvirtWarmMigration
 	return
 }
 

--- a/pkg/controller/plan/adapter/vsphere/validator.go
+++ b/pkg/controller/plan/adapter/vsphere/validator.go
@@ -23,6 +23,13 @@ func (r *Validator) Load() (err error) {
 }
 
 //
+// Validate whether warm migration is supported from this provider type.
+func (r *Validator) WarmMigration() (ok bool) {
+	ok = true
+	return
+}
+
+//
 // Validate that a VM's networks have been mapped.
 func (r *Validator) NetworksMapped(vmRef ref.Ref) (ok bool, err error) {
 	if r.plan.Referenced.Map.Network == nil {

--- a/pkg/settings/features.go
+++ b/pkg/settings/features.go
@@ -1,0 +1,21 @@
+package settings
+
+//
+// Environment Variables
+const (
+	FeatureOvirtWarmMigration = "FEATURE_OVIRT_WARM_MIGRATION"
+)
+
+//
+// Feature gates.
+type Features struct {
+	// Whether migration is supported from oVirt sources.
+	OvirtWarmMigration bool
+}
+
+//
+// Load settings.
+func (r *Features) Load() (err error) {
+	r.OvirtWarmMigration = getEnvBool(FeatureOvirtWarmMigration, false)
+	return
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -27,6 +27,8 @@ type ControllerSettings struct {
 	Logging
 	// Profiler settings.
 	Profiler
+	// Feature gates.
+	Features
 }
 
 //
@@ -57,6 +59,10 @@ func (r *ControllerSettings) Load() error {
 		return err
 	}
 	err = r.Profiler.Load()
+	if err != nil {
+		return err
+	}
+	err = r.Features.Load()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Disables oVirt warm migration by default unless an environment variable is set, since oVirt warm migration support won't be available in Kubevirt until the next Y release.