### PR TITLE
Add ConnectionAuthFailed for one try auth check 

### DIFF
--- a/pkg/controller/provider/container/ovirt/client.go
+++ b/pkg/controller/provider/container/ovirt/client.go
@@ -144,13 +144,13 @@ func (r *Client) auth() (user string) {
 
 //
 // Get system.
-func (r *Client) system() (s *System, err error) {
+func (r *Client) system() (s *System, status int, err error) {
 	err = r.connect()
 	if err != nil {
 		return
 	}
 	system := &System{}
-	status, err := r.client.Get(r.url, system)
+	status, err = r.client.Get(r.url, system)
 	if err != nil {
 		return
 	}

--- a/pkg/controller/provider/container/ovirt/collector.go
+++ b/pkg/controller/provider/container/ovirt/collector.go
@@ -119,8 +119,8 @@ func (r *Collector) HasParity() bool {
 
 //
 // Test connect/logout.
-func (r *Collector) Test() (err error) {
-	_, err = r.client.system()
+func (r *Collector) Test() (status int, err error) {
+	_, status, err = r.client.system()
 	return
 }
 

--- a/pkg/controller/provider/container/vsphere/collector.go
+++ b/pkg/controller/provider/container/vsphere/collector.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	liburl "net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -497,7 +498,7 @@ func (r *Collector) watch() (list []*libmodel.Watch) {
 
 //
 // Build the client.
-func (r *Collector) connect(ctx context.Context) (int, error) {
+func (r *Collector) connect(ctx context.Context) (status int, err error) {
 	r.close()
 	url, err := liburl.Parse(r.url)
 	if err != nil {
@@ -518,7 +519,10 @@ func (r *Collector) connect(ctx context.Context) (int, error) {
 	}
 	err = r.client.Login(ctx, url.User)
 	if err != nil {
-		return http.StatusUnauthorized, liberr.Wrap(err)
+		if strings.Contains(err.Error(), "Cannot complete login due to an incorrect user name or password") {
+			return http.StatusUnauthorized, liberr.Wrap(err)
+		}
+		return 0, liberr.Wrap(err)
 	}
 
 	return http.StatusOK, nil

--- a/pkg/controller/provider/controller.go
+++ b/pkg/controller/provider/controller.go
@@ -232,6 +232,13 @@ func (r Reconciler) Reconcile(request reconcile.Request) (result reconcile.Resul
 		result.RequeueAfter = base.SlowReQ
 	}
 
+	// Stop reconciliation when auth fails
+	if provider.Status.HasCondition(ConnectionAuthFailed) {
+		result.RequeueAfter = 0
+		err = nil
+		return
+	}
+
 	// Done
 	return
 }

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -270,6 +270,7 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 				Message:  "Connection test, succeeded.",
 			})
 	} else {
+		// When the status is unauthorized controller stops the reconciliation, so the user account does not get locked.
 		if status == http.StatusUnauthorized {
 			provider.Status.SetCondition(
 				libcnd.Condition{

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -278,7 +278,7 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 					Reason:   Tested,
 					Category: Critical,
 					Message: fmt.Sprintf(
-						"Connection auth failed, failed: %s",
+						"Connection auth failed, error: %s",
 						err.Error()),
 				})
 			return nil

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	libcnd "github.com/konveyor/controller/pkg/condition"

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -256,7 +256,7 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 		return nil
 	}
 	rl := container.Build(nil, provider, secret)
-	err := rl.Test()
+	status, err := rl.Test()
 	if err == nil {
 		log.Info(
 			"Connection test succeeded.")
@@ -269,7 +269,7 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 				Message:  "Connection test, succeeded.",
 			})
 	} else {
-		if err.Error() == "Unauthorized" {
+		if status == http.StatusUnauthorized {
 			provider.Status.SetCondition(
 				libcnd.Condition{
 					Type:     ConnectionAuthFailed,

--- a/pkg/controller/provider/validation.go
+++ b/pkg/controller/provider/validation.go
@@ -25,6 +25,7 @@ const (
 	Validated               = "Validated"
 	ConnectionTestSucceeded = "ConnectionTestSucceeded"
 	ConnectionTestFailed    = "ConnectionTestFailed"
+	ConnectionAuthFailed    = "ConnectionAuthFailed"
 	InventoryCreated        = "InventoryCreated"
 	LoadInventory           = "LoadInventory"
 )
@@ -268,6 +269,19 @@ func (r *Reconciler) testConnection(provider *api.Provider, secret *core.Secret)
 				Message:  "Connection test, succeeded.",
 			})
 	} else {
+		if err.Error() == "Unauthorized" {
+			provider.Status.SetCondition(
+				libcnd.Condition{
+					Type:     ConnectionAuthFailed,
+					Status:   True,
+					Reason:   Tested,
+					Category: Critical,
+					Message: fmt.Sprintf(
+						"Connection auth failed, failed: %s",
+						err.Error()),
+				})
+			return nil
+		}
 		log.Info(
 			"Connection test failed.",
 			"reason",


### PR DESCRIPTION
Issue: when a user enters the correct username for the provider but incorrect password it will try to connect multiple times to the engine. Which locks the user account.
Fix: Adding a special case of condition `ConnectionAuthFailed` and finish the reconciliation.
Requirement: https://github.com/konveyor/controller/pull/104
