### PR TITLE
Better handling of external tools in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ else
     CONTAINER_CMD = docker
 endif
 
+ifeq (, $(shell which controller-gen))
+    CONTROLLER_GEN := $(GOBIN)/controller-gen
+else
+    CONTROLLER_GEN := $(shell which controller-gen)
+endif
+
 ci: all
 
 all: test manager
@@ -69,14 +75,8 @@ docker-build:
 docker-push:
 	$(CONTAINER_CMD) push ${IMG}
 
-# find or download controller-gen
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN)
 # download controller-gen if necessary
-controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
-	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif
+$(CONTROLLER_GEN):
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,19 @@ GOOS ?= `go env GOOS`
 GOBIN ?= ${GOPATH}/bin
 GO111MODULE = auto
 
-ifeq (, $(shell which docker))
+ifeq (, $(shell which docker 2>/dev/null))
     CONTAINER_CMD = podman
 else
     CONTAINER_CMD = docker
 endif
+$(info Using $(CONTAINER_CMD) to manage containers)
 
-ifeq (, $(shell which controller-gen))
+ifeq (, $(shell which controller-gen 2>/dev/null))
     CONTROLLER_GEN := $(GOBIN)/controller-gen
 else
-    CONTROLLER_GEN := $(shell which controller-gen)
+    CONTROLLER_GEN := $(shell which controller-gen 2>/dev/null)
 endif
+$(info Using controller-gen at $(CONTROLLER_GEN))
 
 ci: all
 


### PR DESCRIPTION
The PR enhances handling of external tools (podman, controller-gen) in Makefile. Changes are following:

* Errors are silenced when looking up tools because they are expected.
* Fix pulling of controller-gen if it is not installed.