### PR TITLE
MTV-323 backport: Change VM names comply with RFC 1123 DNS Subdomain

### DIFF
--- a/pkg/controller/plan/kubevirt.go
+++ b/pkg/controller/plan/kubevirt.go
@@ -4,6 +4,14 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"math/rand"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	template "github.com/openshift/api/template/v1"
 	"github.com/openshift/library-go/pkg/template/generator"
 	"github.com/openshift/library-go/pkg/template/templateprocessing"
@@ -12,14 +20,9 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	cnv "kubevirt.io/client-go/api/v1"
 	libvirtxml "libvirt.org/libvirt-go-xml"
-	"math/rand"
-	"path"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -30,6 +33,7 @@ import (
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	cdi "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +52,10 @@ const (
 	AnnImporterPodName = "cdi.kubevirt.io/storage.import.importPodName"
 	// DV deletion on completion
 	AnnDeleteAfterCompletion = "cdi.kubevirt.io/storage.deleteAfterCompletion"
+	//  Original VM name on source (value=vmOriginalName)
+	AnnOriginalName = "original-name"
+	//  Original VM name on source (value=vmOriginalID)
+	AnnOriginalID = "original-ID"
 )
 
 // Labels
@@ -709,6 +717,27 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus) (object *cnv.VirtualMachine
 		return
 	}
 
+	//If the VM name is not valid according to DNS1123 labeling
+	//convention it will be automatically changed.
+	var originalName string
+
+	if errs := k8svalidation.IsDNS1123Label(vm.Name); len(errs) > 0 {
+		originalName = vm.Name
+
+		generatedName := changeVmName(vm.Name, vm.ID)
+		nameExist, errName := r.checkIfVmNameExist(generatedName)
+		if errName != nil {
+			err = liberr.Wrap(errName)
+			return
+		}
+		if nameExist {
+			generatedName = generatedName + "-" + vm.ID[:4]
+		}
+		vm.Name = generatedName
+		r.Log.Info("VM name ", originalName, " was incompatible with DNS1123 RFC, changing to ",
+			vm.String())
+	}
+
 	var ok bool
 	object, ok = r.vmTemplate(vm)
 	if !ok {
@@ -716,6 +745,13 @@ func (r *KubeVirt) virtualMachine(vm *plan.VMStatus) (object *cnv.VirtualMachine
 			"vm",
 			vm.String())
 		object = r.emptyVm(vm)
+	}
+	//Add the original name and ID info to the VM annotations
+	if len(originalName) > 0 {
+		annotations := make(map[string]string)
+		annotations[AnnOriginalName] = originalName
+		annotations[AnnOriginalID] = vm.ID
+		object.ObjectMeta.Annotations = annotations
 	}
 	running := false
 	object.Spec.Running = &running
@@ -1297,6 +1333,39 @@ func (r *KubeVirt) vmLabels(vmRef ref.Ref) (labels map[string]string) {
 }
 
 //
+// Checks if VM with the newly generated name exists on the destination
+func (r *KubeVirt) checkIfVmNameExist(name string) (nameExist bool, err error) {
+	list := &cnv.VirtualMachineList{}
+	nameFiled := "metadata.name"
+	listOptions := &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(nameFiled, name),
+	}
+	err = r.Destination.Client.List(
+		context.TODO(),
+		list,
+		listOptions,
+	)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	if len(list.Items) > 0 {
+		nameExist = true
+		return
+	}
+	// Checks that the new name does not match a valid
+	// VM name in the same plan
+	for _, vm := range r.Migration.Status.VMs {
+		if vm.Name == name {
+			nameExist = true
+			return
+		}
+	}
+	nameExist = false
+	return
+}
+
+//
 // Represents a CDI DataVolume and add behavior.
 type DataVolume struct {
 	*cdi.DataVolume
@@ -1401,4 +1470,33 @@ func vmOwnerReference(vm *cnv.VirtualMachine) (ref meta.OwnerReference) {
 		Controller:         &isController,
 	}
 	return
+}
+
+//changes VM name to match DNS1123 RFC convention.
+func changeVmName(currName string, vmID string) string {
+
+	var nameMaxLength int = 63
+	var underscoreExcluded = regexp.MustCompile("[_]")
+	var nameExcludeChars = regexp.MustCompile("[^a-z0-9-]")
+
+	newName := strings.ToLower(currName)
+	if len(newName) > nameMaxLength {
+		newName = newName[0:nameMaxLength]
+	}
+	if underscoreExcluded.MatchString(newName) {
+		newName = underscoreExcluded.ReplaceAllString(newName, "-")
+	}
+	if nameExcludeChars.MatchString(newName) {
+		newName = nameExcludeChars.ReplaceAllString(newName, "")
+	}
+	for strings.HasPrefix(newName, "-") {
+		newName = newName[1:]
+	}
+	for strings.HasSuffix(newName, "-") {
+		newName = newName[:len(newName)-1]
+	}
+	if len(newName) == 0 {
+		newName = "vm-" + vmID[:4]
+	}
+	return newName
 }

--- a/pkg/controller/plan/kubevirt_test.go
+++ b/pkg/controller/plan/kubevirt_test.go
@@ -1,0 +1,22 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestKubevirt(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	id := "1234-5678"
+
+	//Test all cases in name adjustments
+	originalVmName := "----------------Vm!@#$%^&*()_+Name/.,';[]_CorREct_<>123----------------------"
+	newVmName := "vm-name-correct-123"
+	g.Expect(changeVmName(originalVmName, id)).To(gomega.Equal(newVmName))
+
+	//Test the case that the VM name is empty after all removals
+	emptyVM := ".__."
+	newVmNameFromId := "vm-1234"
+	g.Expect(changeVmName(emptyVM, id)).To(gomega.Equal(newVmNameFromId))
+}

--- a/pkg/controller/plan/validation.go
+++ b/pkg/controller/plan/validation.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
+
 	net "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	libcnd "github.com/konveyor/controller/pkg/condition"
 	liberr "github.com/konveyor/controller/pkg/error"
@@ -15,7 +17,6 @@ import (
 	"github.com/konveyor/forklift-controller/pkg/controller/validation"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
-	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -317,8 +318,8 @@ func (r *Reconciler) validateVM(plan *api.Plan) error {
 		Type:     NameNotValid,
 		Status:   True,
 		Reason:   NotValid,
-		Category: Critical,
-		Message:  "Target VM name not valid.",
+		Category: Warn,
+		Message:  "Target VM name does not comply with DNS1123 RFC, will be automatically changed.",
 		Items:    []string{},
 	}
 	alreadyExists := libcnd.Condition{


### PR DESCRIPTION
This PR changes VMs names to match the DNS1123 RFC conventions,
As a first step, the names will be automatically adjusted to make the VMs ready for migration without user actions.
A newly generated name will be created and validated with the destination, if exists, will add the first 4 chars from the ID to the new name to avoid dups.
A new annotation with the previous name and ID will be added to the imported VM.

Currently, implementation checks the following:

contain at most 63 characters
contain only lowercase alphanumeric characters or '-'
start with an alphanumeric character
end with an alphanumeric character
In case the VM name is completely deleted after the adjustments a new name in the format vm-$ID will be given.

https://bugzilla.redhat.com/show_bug.cgi?id=1959883

This https://github.com/konveyor/forklift-validation/pull/47 changes the validation displayed message.