### PR TITLE
Switch to non-secure EFI

### DIFF
--- a/pkg/controller/plan/adapter/ovirt/builder.go
+++ b/pkg/controller/plan/adapter/ovirt/builder.go
@@ -22,6 +22,7 @@ import (
 const (
 	ClusterDefault = "cluster_default"
 	Q35Ovmf        = "q35_ovmf"
+	Q35SecureBoot  = "q35_secure_boot"
 )
 
 // Bus types
@@ -373,12 +374,12 @@ func (r *Builder) mapFirmware(vm *model.Workload, cluster *model.Cluster, object
 		Serial: serial,
 	}
 	switch biosType {
-	case Q35Ovmf:
-		smmEnabled := true
-		features.SMM = &cnv.FeatureState{
-			Enabled: &smmEnabled,
-		}
-		firmware.Bootloader = &cnv.Bootloader{EFI: &cnv.EFI{}}
+	case Q35Ovmf, Q35SecureBoot:
+		secureBootEnabled := false
+		firmware.Bootloader = &cnv.Bootloader{
+			EFI: &cnv.EFI{
+				SecureBoot: &secureBootEnabled,
+			}}
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}

--- a/pkg/controller/plan/adapter/vsphere/builder.go
+++ b/pkg/controller/plan/adapter/vsphere/builder.go
@@ -454,11 +454,11 @@ func (r *Builder) mapFirmware(vm *model.VM, object *cnv.VirtualMachineSpec) {
 	}
 	switch vm.Firmware {
 	case Efi:
-		smmEnabled := true
-		features.SMM = &cnv.FeatureState{
-			Enabled: &smmEnabled,
-		}
-		firmware.Bootloader = &cnv.Bootloader{EFI: &cnv.EFI{}}
+		secureBootEnabled := false
+		firmware.Bootloader = &cnv.Bootloader{
+			EFI: &cnv.EFI{
+				SecureBoot: &secureBootEnabled,
+			}}
 	default:
 		firmware.Bootloader = &cnv.Bootloader{BIOS: &cnv.BIOS{}}
 	}


### PR DESCRIPTION
Since we can't transfer NVRAM or TPM data, it is better to have EFI VMs without secure boot.